### PR TITLE
Increasing wrong character timeout to 30 to fix 'no annoucement' error.

### DIFF
--- a/tools/artemis/artemis_svl.py
+++ b/tools/artemis/artemis_svl.py
@@ -4,7 +4,7 @@
 # This script was originally written by Ambiq
 # Modified April 2nd, 2019 by SparkFun to auto-bootloading
 # Compiled to executable using pyInstaller
-# pyinstaller --onefile artemis_uart_loader.py
+# pyinstaller --onefile artemis_svl.py
 
 import argparse
 import serial
@@ -86,12 +86,12 @@ def main():
 
         verboseprint("Waiting for command from bootloader")
 
-        # Wait for incoming char(5) indicating ability to boot
+        # Wait for incoming BL_COMMAND_ANNOUNCE
         i = 0
         response = ''
         while len(response) == 0:
             i = i + 1
-            if(i == 10):
+            if(i == 30):
                 print("No announcement from Artemis bootloader")
                 exit()
 


### PR DESCRIPTION
I had a sketch reporting 'No announcement from Artemis bootloader'. This occurs when either 1) no chr(127) is received or 2) too many non-chr(127) characters are received. The sketch I was working on transmits a ton of serial data at 115200 constantly. After the Artemis is reset, the python script has more than 10 bytes sitting in the buffer. 30 seems to work well. With a 0.1s timeout, this is 3s total. Increasing to 50 seems overkill.