### PR TITLE
Add enableBurstMode() function and example to core.

### DIFF
--- a/cores/arduino/ard_sup/Arduino.h
+++ b/cores/arduino/ard_sup/Arduino.h
@@ -76,6 +76,7 @@ extern "C"
 #include "ap3_debugging.h"
 #include "ap3_uart.h"
 #include "ap3_analog.h"
+#include "ap3_clock_sources.h"
 #include "WMath.h"
 #include "WCharacter.h"
 

--- a/cores/arduino/ard_sup/ap3_clock_sources.h
+++ b/cores/arduino/ard_sup/ap3_clock_sources.h
@@ -1,0 +1,30 @@
+/*
+Copyright (c) 2019 SparkFun Electronics
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.
+*/
+#ifndef _AP3_CLOCK_SOURCES_H_
+#define _AP3_CLOCK_SOURCES_H_
+
+#include "Arduino.h"
+
+bool enableBurstMode();
+bool disableBurstMode();
+
+#endif //_AP3_GPIO_H_

--- a/cores/arduino/ard_sup/clock/ap3_clock_sources.cpp
+++ b/cores/arduino/ard_sup/clock/ap3_clock_sources.cpp
@@ -1,0 +1,40 @@
+#include "ap3_clock_sources.h"
+
+//Turns main processor from 48MHz to 96MHz
+//Returns false if burst mode failed to enable
+bool enableBurstMode(void)
+{
+    // Check that the Burst Feature is available.
+    am_hal_burst_avail_e eBurstModeAvailable;
+    if (AM_HAL_STATUS_SUCCESS != am_hal_burst_mode_initialize(&eBurstModeAvailable))
+    {
+        return (false);
+    }
+
+    // Put the MCU into "Burst" mode.
+    am_hal_burst_mode_e eBurstMode;
+    if (AM_HAL_STATUS_SUCCESS != am_hal_burst_mode_enable(&eBurstMode))
+    {
+        return (false);
+    }
+    return (true);
+}
+
+//Turns main processor from 96MHz to 48MHz
+//Returns false if disable fails
+bool disableBurstMode(void)
+{
+    am_hal_burst_mode_e eBurstMode;
+    if (AM_HAL_STATUS_SUCCESS == am_hal_burst_mode_disable(&eBurstMode))
+    {
+        if (AM_HAL_NORMAL_MODE != eBurstMode)
+        {
+            return (false);
+        }
+    }
+    else
+    {
+        return (false);
+    }
+    return (true);
+}

--- a/libraries/CoreTesting/examples/Advanced/BurstMode/BurstMode.ino
+++ b/libraries/CoreTesting/examples/Advanced/BurstMode/BurstMode.ino
@@ -1,0 +1,82 @@
+/*
+  Increasing core speed to 96MHz
+  By: Nathan Seidle
+  SparkFun Electronics
+  Date: June 24th, 2019
+  License: This code is public domain but the prime number function
+  comes from Ambiq/John Burkardt and has a GNU LGPL license. Additional
+  code based on Ambiq's burst example.
+
+  SparkFun labored with love to create this code. Feel like supporting open source hardware?
+  Buy a board from SparkFun! https://www.sparkfun.com/products/15376
+
+  This example shows how to increase the core speed from 48MHz to 96MHz.
+
+  Increasing the core speed will increase current consumption. And increase in core
+  speed is useful for calculations and minimizing code run time. Burst mode does not increase
+  the speed at which GPIO can toggle.  
+*/
+
+long startTime;
+long endTime;
+int count = 0;
+
+//Make true if you want to print the prime numbers
+//Printing output will destroy the accuracy of the timing
+bool printThePrimes = false;
+
+void setup() {
+  Serial.begin(9600);
+  Serial.println("Calculating primes with burst mode");
+
+  startTime = millis();
+  count = numberOfPrimes(10000); //Find the number of primes in 10,000
+  endTime = millis();
+
+  Serial.printf("Total primes found (should be 1229): %d\n", count);
+  Serial.printf("Time required at 48MHz: %dms\n", endTime - startTime);
+
+  enableBurstMode(); //Go to 96MHz
+  startTime = millis();
+  count = numberOfPrimes(10000); //Find the number of primes in 10,000
+  endTime = millis();
+  disableBurstMode(); //Return to 48MHz
+
+  Serial.printf("Total primes found (should be 1229): %d\n", count);
+  Serial.printf("Time required in burst mode: %dms\n", endTime - startTime);
+}
+
+void loop() {
+  //Do nothing
+}
+
+// Returns the number of primes between 1 and N.
+// A naive algorithm is used.
+// Input, int N, the maximum number to check.
+// Output, int PRIME_NUMBER, the number of prime numbers up to N.
+int numberOfPrimes(int maxToSearch)
+{
+  uint32_t ui32Total, ui32Prime;
+  int32_t ix, jx;
+
+  ui32Total = 0;
+
+  for ( ix = 2; ix <= maxToSearch; ix++ )
+  {
+    ui32Prime = 1;
+    for ( jx = 2; jx < ix; jx++ )
+    {
+      if ( (ix % jx) == 0 )
+      {
+        ui32Prime = 0;
+        break;
+      }
+    }
+    if (ui32Prime == 1 && printThePrimes == true)
+    {
+      Serial.printf("Prime found: %d\n", ix);
+    }
+    ui32Total += ui32Prime;
+  }
+  return ui32Total;
+}


### PR DESCRIPTION
Allows users to run at 96MHz or 48MHz

I created two new functions called:

* enableBurstMode()
* disableBurstMode()

I welcome feedback if you want to do a different new-to-arduino naming convention.