### PR TITLE
Add shiftIn/shiftOut as well as fastShiftIn/fastShiftOut

### DIFF
--- a/cores/arduino/am_sdk_ap3/mcu/apollo3/hal/am_hal_gpio.h
+++ b/cores/arduino/am_sdk_ap3/mcu/apollo3/hal/am_hal_gpio.h
@@ -689,6 +689,7 @@ extern "C"
 // Note - these macros are most efficient if 'n' is a constant value, and
 //        of course when compiled with -O3.
 //
+#define am_hal_gpio_fastgpio_read(n) ((APBDMA->BBINPUT >> (n & 0x7)) & 0x1)
 #define am_hal_gpio_fastgpio_set(n) (APBDMA->BBSETCLEAR = _VAL2FLD(APBDMA_BBSETCLEAR_SET, (1 << (n & 0x7))))
 #define am_hal_gpio_fastgpio_clr(n) (APBDMA->BBSETCLEAR = _VAL2FLD(APBDMA_BBSETCLEAR_CLEAR, (1 << (n & 0x7))))
 #define am_hal_gpio_fastgpio_setmsk(m) (APBDMA->BBSETCLEAR = _VAL2FLD(APBDMA_BBSETCLEAR_SET, m))

--- a/cores/arduino/am_sdk_ap3/mcu/apollo3/hal/am_hal_gpio.h
+++ b/cores/arduino/am_sdk_ap3/mcu/apollo3/hal/am_hal_gpio.h
@@ -15,24 +15,24 @@
 //
 // Copyright (c) 2019, Ambiq Micro
 // All rights reserved.
-// 
+//
 // Redistribution and use in source and binary forms, with or without
 // modification, are permitted provided that the following conditions are met:
-// 
+//
 // 1. Redistributions of source code must retain the above copyright notice,
 // this list of conditions and the following disclaimer.
-// 
+//
 // 2. Redistributions in binary form must reproduce the above copyright
 // notice, this list of conditions and the following disclaimer in the
 // documentation and/or other materials provided with the distribution.
-// 
+//
 // 3. Neither the name of the copyright holder nor the names of its
 // contributors may be used to endorse or promote products derived from this
 // software without specific prior written permission.
-// 
+//
 // Third party software included in this distribution is subject to the
 // additional license terms as defined in the /docs/licenses directory.
-// 
+//
 // THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
 // AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
 // IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
@@ -50,7 +50,7 @@
 //*****************************************************************************
 
 #ifndef AM_HAL_GPIO_H
-#define AM_HAL_GPIO_H   1
+#define AM_HAL_GPIO_H 1
 
 #ifdef __cplusplus
 extern "C"
@@ -60,207 +60,205 @@ extern "C"
 //
 // Designate this peripheral.
 //
-#define AM_APOLLO3_GPIO     1
+#define AM_APOLLO3_GPIO 1
 
 //
 // Maximum number of GPIOs on this device
 //
-#define AM_HAL_GPIO_MAX_PADS        (50)
+#define AM_HAL_GPIO_MAX_PADS (50)
 
 //
 // Macro to assist with defining a GPIO bit given a GPIO number.
 //
-#define AM_HAL_GPIO_BIT(n)          (((uint64_t) 0x1) << n)
+#define AM_HAL_GPIO_BIT(n) (((uint64_t)0x1) << n)
 
-//*****************************************************************************
-//!
-//! Read types for am_hal_gpio_state_read().
-//!
-//*****************************************************************************
-typedef enum
-{
-    AM_HAL_GPIO_INPUT_READ,
-    AM_HAL_GPIO_OUTPUT_READ,
-    AM_HAL_GPIO_ENABLE_READ
-} am_hal_gpio_read_type_e;
+    //*****************************************************************************
+    //!
+    //! Read types for am_hal_gpio_state_read().
+    //!
+    //*****************************************************************************
+    typedef enum
+    {
+        AM_HAL_GPIO_INPUT_READ,
+        AM_HAL_GPIO_OUTPUT_READ,
+        AM_HAL_GPIO_ENABLE_READ
+    } am_hal_gpio_read_type_e;
 
-//*****************************************************************************
-//!
-//! Write types for am_hal_gpio_state_write().
-//!
-//*****************************************************************************
-typedef enum
-{
-    AM_HAL_GPIO_OUTPUT_CLEAR,
-    AM_HAL_GPIO_OUTPUT_SET,
-    AM_HAL_GPIO_OUTPUT_TOGGLE,
-    AM_HAL_GPIO_OUTPUT_TRISTATE_DISABLE,
-    AM_HAL_GPIO_OUTPUT_TRISTATE_ENABLE,
-    AM_HAL_GPIO_OUTPUT_TRISTATE_TOGGLE
-} am_hal_gpio_write_type_e;
+    //*****************************************************************************
+    //!
+    //! Write types for am_hal_gpio_state_write().
+    //!
+    //*****************************************************************************
+    typedef enum
+    {
+        AM_HAL_GPIO_OUTPUT_CLEAR,
+        AM_HAL_GPIO_OUTPUT_SET,
+        AM_HAL_GPIO_OUTPUT_TOGGLE,
+        AM_HAL_GPIO_OUTPUT_TRISTATE_DISABLE,
+        AM_HAL_GPIO_OUTPUT_TRISTATE_ENABLE,
+        AM_HAL_GPIO_OUTPUT_TRISTATE_TOGGLE
+    } am_hal_gpio_write_type_e;
 
+    //*****************************************************************************
+    //!
+    //! Types for ui32GpioCfg bitfields in am_hal_gpio_pinconfig().
+    //!
+    //*****************************************************************************
+    //!
+    //! Power Switch configuration: am_hal_gpio_pincfg_t.ePowerSw enums
+    //!
+    typedef enum
+    {
+        AM_HAL_GPIO_PIN_POWERSW_NONE,
+        AM_HAL_GPIO_PIN_POWERSW_VDD,
+        AM_HAL_GPIO_PIN_POWERSW_VSS,
+        AM_HAL_GPIO_PIN_POWERSW_INVALID,
+    } am_hal_gpio_powersw_e;
 
-//*****************************************************************************
-//!
-//! Types for ui32GpioCfg bitfields in am_hal_gpio_pinconfig().
-//!
-//*****************************************************************************
-//!
-//! Power Switch configuration: am_hal_gpio_pincfg_t.ePowerSw enums
-//!
-typedef enum
-{
-    AM_HAL_GPIO_PIN_POWERSW_NONE,
-    AM_HAL_GPIO_PIN_POWERSW_VDD,
-    AM_HAL_GPIO_PIN_POWERSW_VSS,
-    AM_HAL_GPIO_PIN_POWERSW_INVALID,
-} am_hal_gpio_powersw_e;
+    //!
+    //! Pullup configuration: am_hal_gpio_pincfg_t.ePullup enums
+    //!
+    typedef enum
+    {
+        //
+        //! Define pullup enums.
+        //! The 1.5K - 24K pullup values are valid for select I2C enabled pads.
+        //! For Apollo3 these pins are 0-1,5-6,8-9,25,27,39-40,42-43,48-49.
+        //! The "weak" value is used for almost every other pad except pin 20.
+        //
+        AM_HAL_GPIO_PIN_PULLUP_NONE = 0x00,
+        AM_HAL_GPIO_PIN_PULLUP_WEAK,
+        AM_HAL_GPIO_PIN_PULLUP_1_5K,
+        AM_HAL_GPIO_PIN_PULLUP_6K,
+        AM_HAL_GPIO_PIN_PULLUP_12K,
+        AM_HAL_GPIO_PIN_PULLUP_24K,
+        AM_HAL_GPIO_PIN_PULLDOWN
+    } am_hal_gpio_pullup_e;
 
-//!
-//! Pullup configuration: am_hal_gpio_pincfg_t.ePullup enums
-//!
-typedef enum
-{
-    //
-    //! Define pullup enums.
-    //! The 1.5K - 24K pullup values are valid for select I2C enabled pads.
-    //! For Apollo3 these pins are 0-1,5-6,8-9,25,27,39-40,42-43,48-49.
-    //! The "weak" value is used for almost every other pad except pin 20.
-    //
-    AM_HAL_GPIO_PIN_PULLUP_NONE = 0x00,
-    AM_HAL_GPIO_PIN_PULLUP_WEAK,
-    AM_HAL_GPIO_PIN_PULLUP_1_5K,
-    AM_HAL_GPIO_PIN_PULLUP_6K,
-    AM_HAL_GPIO_PIN_PULLUP_12K,
-    AM_HAL_GPIO_PIN_PULLUP_24K,
-    AM_HAL_GPIO_PIN_PULLDOWN
-} am_hal_gpio_pullup_e;
+    //!
+    //! Pad Drive Strength configuration: am_hal_gpio_pincfg_t.eDriveStrength enums
+    //!
+    typedef enum
+    {
+        //
+        //! DRIVESTRENGTH is a 2-bit field.
+        //!  bit0 maps to bit2 of a PADREG field.
+        //!  bit1 maps to bit0 of an ALTPADCFG field.
+        //
+        AM_HAL_GPIO_PIN_DRIVESTRENGTH_2MA = 0x0,
+        AM_HAL_GPIO_PIN_DRIVESTRENGTH_4MA = 0x1,
+        AM_HAL_GPIO_PIN_DRIVESTRENGTH_8MA = 0x2,
+        AM_HAL_GPIO_PIN_DRIVESTRENGTH_12MA = 0x3
+    } am_hal_gpio_drivestrength_e;
 
-//!
-//! Pad Drive Strength configuration: am_hal_gpio_pincfg_t.eDriveStrength enums
-//!
-typedef enum
-{
-    //
-    //! DRIVESTRENGTH is a 2-bit field.
-    //!  bit0 maps to bit2 of a PADREG field.
-    //!  bit1 maps to bit0 of an ALTPADCFG field.
-    //
-    AM_HAL_GPIO_PIN_DRIVESTRENGTH_2MA   = 0x0,
-    AM_HAL_GPIO_PIN_DRIVESTRENGTH_4MA   = 0x1,
-    AM_HAL_GPIO_PIN_DRIVESTRENGTH_8MA   = 0x2,
-    AM_HAL_GPIO_PIN_DRIVESTRENGTH_12MA  = 0x3
-} am_hal_gpio_drivestrength_e;
+    //!
+    //! OUTCFG pad configuration: am_hal_gpio_pincfg_t.eGPOutcfg enums
+    //! Applies only to GPIO configured pins.
+    //! Ultimately maps to GPIOCFG.OUTCFG, bits [2:1].
+    //!
+    typedef enum
+    {
+        AM_HAL_GPIO_PIN_OUTCFG_DISABLE = 0x0,
+        AM_HAL_GPIO_PIN_OUTCFG_PUSHPULL = 0x1,
+        AM_HAL_GPIO_PIN_OUTCFG_OPENDRAIN = 0x2,
+        AM_HAL_GPIO_PIN_OUTCFG_TRISTATE = 0x3
+    } am_hal_gpio_outcfg_e;
 
-//!
-//! OUTCFG pad configuration: am_hal_gpio_pincfg_t.eGPOutcfg enums
-//! Applies only to GPIO configured pins.
-//! Ultimately maps to GPIOCFG.OUTCFG, bits [2:1].
-//!
-typedef enum
-{
-    AM_HAL_GPIO_PIN_OUTCFG_DISABLE     = 0x0,
-    AM_HAL_GPIO_PIN_OUTCFG_PUSHPULL    = 0x1,
-    AM_HAL_GPIO_PIN_OUTCFG_OPENDRAIN   = 0x2,
-    AM_HAL_GPIO_PIN_OUTCFG_TRISTATE    = 0x3
-} am_hal_gpio_outcfg_e;
+    //!
+    //! GPIO input configuration: am_hal_gpio_pincfg_t.eGPInput enums
+    //! Applies only to GPIO configured pins!
+    //! Ultimately maps to PADREG.INPEN, bit1.
+    //!
+    typedef enum
+    {
+        AM_HAL_GPIO_PIN_INPUT_AUTO = 0x0,
+        AM_HAL_GPIO_PIN_INPUT_NONE = 0x0,
+        AM_HAL_GPIO_PIN_INPUT_ENABLE = 0x1
+    } am_hal_gpio_input_e;
 
-//!
-//! GPIO input configuration: am_hal_gpio_pincfg_t.eGPInput enums
-//! Applies only to GPIO configured pins!
-//! Ultimately maps to PADREG.INPEN, bit1.
-//!
-typedef enum
-{
-    AM_HAL_GPIO_PIN_INPUT_AUTO          = 0x0,
-    AM_HAL_GPIO_PIN_INPUT_NONE          = 0x0,
-    AM_HAL_GPIO_PIN_INPUT_ENABLE        = 0x1
-} am_hal_gpio_input_e;
+    //!
+    //! GPIO interrupt direction configuration: am_hal_gpio_pincfg_t.eIntDir enums
+    //! Note: Setting INTDIR_NONE has the side-effect of disabling being able to
+    //!       read a pin - the pin will always read back as 0.
+    //!
+    typedef enum
+    {
+        // Bit1 of these values maps to GPIOCFG.INCFG (b0).
+        // Bit0 of these values maps to GPIOCFG.INTD  (b3).
+        AM_HAL_GPIO_PIN_INTDIR_LO2HI = 0x0,
+        AM_HAL_GPIO_PIN_INTDIR_HI2LO = 0x1,
+        AM_HAL_GPIO_PIN_INTDIR_NONE = 0x2,
+        AM_HAL_GPIO_PIN_INTDIR_BOTH = 0x3
+    } am_hal_gpio_intdir_e;
 
-//!
-//! GPIO interrupt direction configuration: am_hal_gpio_pincfg_t.eIntDir enums
-//! Note: Setting INTDIR_NONE has the side-effect of disabling being able to
-//!       read a pin - the pin will always read back as 0.
-//!
-typedef enum
-{
-    // Bit1 of these values maps to GPIOCFG.INCFG (b0).
-    // Bit0 of these values maps to GPIOCFG.INTD  (b3).
-    AM_HAL_GPIO_PIN_INTDIR_LO2HI        = 0x0,
-    AM_HAL_GPIO_PIN_INTDIR_HI2LO        = 0x1,
-    AM_HAL_GPIO_PIN_INTDIR_NONE         = 0x2,
-    AM_HAL_GPIO_PIN_INTDIR_BOTH         = 0x3
-} am_hal_gpio_intdir_e;
+    //!
+    //! am_hal_gpio_pincfg_t.eGPRdZero
+    //! For GPIO configurations (funcsel=3), the pin value can be read or 0 can be
+    //! forced as the read value.
+    //!
+    typedef enum
+    {
+        AM_HAL_GPIO_PIN_RDZERO_READPIN = 0x0,
+        AM_HAL_GPIO_PIN_RDZERO_ZERO = 0x1
+    } am_hal_gpio_readen_e;
 
-//!
-//! am_hal_gpio_pincfg_t.eGPRdZero
-//! For GPIO configurations (funcsel=3), the pin value can be read or 0 can be
-//! forced as the read value.
-//!
-typedef enum
-{
-    AM_HAL_GPIO_PIN_RDZERO_READPIN      = 0x0,
-    AM_HAL_GPIO_PIN_RDZERO_ZERO         = 0x1
-} am_hal_gpio_readen_e;
-
-//!
-//! nCE polarity configuration: am_hal_gpio_pincfg_t.eCEpol enums
-//!
-typedef enum
-{
-    AM_HAL_GPIO_PIN_CEPOL_ACTIVELOW     = 0x0,
-    AM_HAL_GPIO_PIN_CEPOL_ACTIVEHIGH    = 0x1
-} am_hal_gpio_cepol_e;
-
-
-//
-// Apollo3 usage of bits [7:6] of a PADREG field:
-// PULLUPs are available on pins: 0,1,5,6,8,9,25,27,39,40,42,43,48,49
-// RESERVED on pins:              2,4,7,10-24,26,28-35,38,44-47
-// VDD PWR on pins:               3, 36 (b7=0, b6=1)
-// VSS PWR on pins:               37,41 (b7=1, b6=0)
-//
-
-//!
-//! Define the am_hal_gpio_pinconfig() bitfield structure.
-//!  uFuncSel a value of 0-7 corresponding to the FNCSEL field of PADREG.
-//!  ePowerSw: Select pins can be set as a power source or sink.
-//!  ePullup:  Select pins can enable a pullup of varying values.
-//!  eDriveStrength: Select pins can be set for varying drive strengths.
-//!  eGPOutcfg: GPIO pin only, corresponds to GPIOCFG.OUTCFG field.
-//!  eGPInput:  GPIO pin only, corresponds to PADREG.INPEN.
-//!  eGPRdZero: GPIO read zero.  Corresponds to GPIOCFG.INCFG.
-//!  eIntDir: Interrupt direction, l2h, h2l, both, none.
-//!  eGPRdZero: Read the pin value, or always read the pin as zero.
-//!  uIOMnum: nCE pin IOMnumber (0-5, or 6 for MSPI)
-//!  nNCE: Selects the SPI channel (CE) number (0-3)
-//!  eCEpol: CE polarity.
-//!
-typedef struct
-{
-    uint32_t uFuncSel       : 3;    // [2:0]   Function select (FUNCSEL)
-    uint32_t ePowerSw       : 2;    // [4:3]   Pin is a power switch source (VCC) or sink (VSS)
-    uint32_t ePullup        : 3;    // [7:5]   Pin will enable a pullup resistor
-    uint32_t eDriveStrength : 2;    // [9:8]   Pad strength designator
-    uint32_t eGPOutcfg      : 2;    // [11:10] OUTCFG (GPIO config only)
-    uint32_t eGPInput       : 1;    // [12:12] GPIO Input (GPIO config only)
-    uint32_t eIntDir        : 2;    // [14:13] Interrupt direction
-    uint32_t eGPRdZero      : 1;    // [15:15] GPIO read as zero
+    //!
+    //! nCE polarity configuration: am_hal_gpio_pincfg_t.eCEpol enums
+    //!
+    typedef enum
+    {
+        AM_HAL_GPIO_PIN_CEPOL_ACTIVELOW = 0x0,
+        AM_HAL_GPIO_PIN_CEPOL_ACTIVEHIGH = 0x1
+    } am_hal_gpio_cepol_e;
 
     //
-    // The following descriptors designate the chip enable features of the
-    // pin being configured.  If not a CE, these descriptors are ignored.
-    // uIOMnum is 0-5 for the IOMs, or 6 for MSPI, 7 is invalid.
+    // Apollo3 usage of bits [7:6] of a PADREG field:
+    // PULLUPs are available on pins: 0,1,5,6,8,9,25,27,39,40,42,43,48,49
+    // RESERVED on pins:              2,4,7,10-24,26,28-35,38,44-47
+    // VDD PWR on pins:               3, 36 (b7=0, b6=1)
+    // VSS PWR on pins:               37,41 (b7=1, b6=0)
     //
-    uint32_t uIOMnum        : 3;    // [18:16] IOM number (0-5), 6 for MSPI
-    uint32_t uNCE           : 2;    // [20:19] NCE number (0-3).
-    uint32_t eCEpol         : 1;    // [21:21] NCE polarity.
 
-    uint32_t uRsvd22        : 10;    // [31:22]
-} am_hal_gpio_pincfg_t;
+    //!
+    //! Define the am_hal_gpio_pinconfig() bitfield structure.
+    //!  uFuncSel a value of 0-7 corresponding to the FNCSEL field of PADREG.
+    //!  ePowerSw: Select pins can be set as a power source or sink.
+    //!  ePullup:  Select pins can enable a pullup of varying values.
+    //!  eDriveStrength: Select pins can be set for varying drive strengths.
+    //!  eGPOutcfg: GPIO pin only, corresponds to GPIOCFG.OUTCFG field.
+    //!  eGPInput:  GPIO pin only, corresponds to PADREG.INPEN.
+    //!  eGPRdZero: GPIO read zero.  Corresponds to GPIOCFG.INCFG.
+    //!  eIntDir: Interrupt direction, l2h, h2l, both, none.
+    //!  eGPRdZero: Read the pin value, or always read the pin as zero.
+    //!  uIOMnum: nCE pin IOMnumber (0-5, or 6 for MSPI)
+    //!  nNCE: Selects the SPI channel (CE) number (0-3)
+    //!  eCEpol: CE polarity.
+    //!
+    typedef struct
+    {
+        uint32_t uFuncSel : 3;       // [2:0]   Function select (FUNCSEL)
+        uint32_t ePowerSw : 2;       // [4:3]   Pin is a power switch source (VCC) or sink (VSS)
+        uint32_t ePullup : 3;        // [7:5]   Pin will enable a pullup resistor
+        uint32_t eDriveStrength : 2; // [9:8]   Pad strength designator
+        uint32_t eGPOutcfg : 2;      // [11:10] OUTCFG (GPIO config only)
+        uint32_t eGPInput : 1;       // [12:12] GPIO Input (GPIO config only)
+        uint32_t eIntDir : 2;        // [14:13] Interrupt direction
+        uint32_t eGPRdZero : 1;      // [15:15] GPIO read as zero
 
-#define IOMNUM_MSPI         6
-#define IOMNUM_MAX          IOMNUM_MSPI
+        //
+        // The following descriptors designate the chip enable features of the
+        // pin being configured.  If not a CE, these descriptors are ignored.
+        // uIOMnum is 0-5 for the IOMs, or 6 for MSPI, 7 is invalid.
+        //
+        uint32_t uIOMnum : 3; // [18:16] IOM number (0-5), 6 for MSPI
+        uint32_t uNCE : 2;    // [20:19] NCE number (0-3).
+        uint32_t eCEpol : 1;  // [21:21] NCE polarity.
+
+        uint32_t uRsvd22 : 10; // [31:22]
+    } am_hal_gpio_pincfg_t;
+
+#define IOMNUM_MSPI 6
+#define IOMNUM_MAX IOMNUM_MSPI
 
 //
 // Define shift and width values for the above bitfields.
@@ -269,315 +267,314 @@ typedef struct
 //   GCC, the bitfields are all exactly as defined in the above structure.
 // - These defines should be used sparingly.
 //
-#define UFUNCSEL_S          0
-#define EPOWERSW_S          3
-#define EPULLUP_S           5
-#define EDRVSTR_S           8
-#define EGPOUTCFG_S         10
-#define EGPINPUT_S          12
-#define EINTDIR_S           13
-#define UIOMNUM_S           16
-#define UNCE_S              19
-#define ECEPOL_S            21
+#define UFUNCSEL_S 0
+#define EPOWERSW_S 3
+#define EPULLUP_S 5
+#define EDRVSTR_S 8
+#define EGPOUTCFG_S 10
+#define EGPINPUT_S 12
+#define EINTDIR_S 13
+#define UIOMNUM_S 16
+#define UNCE_S 19
+#define ECEPOL_S 21
 
-#define UFUNCSEL_W          3
-#define EPOWERSW_W          2
-#define EPULLUP_W           3
-#define EDRVSTR_W           2
-#define EGPOUTCFG_W         2
-#define EGPINPUT_W          1
-#define EINTDIR_W           2
-#define UIOMNUM_W           3
-#define UNCE_W              2
-#define ECEPOL_W            1
+#define UFUNCSEL_W 3
+#define EPOWERSW_W 2
+#define EPULLUP_W 3
+#define EDRVSTR_W 2
+#define EGPOUTCFG_W 2
+#define EGPINPUT_W 1
+#define EINTDIR_W 2
+#define UIOMNUM_W 3
+#define UNCE_W 2
+#define ECEPOL_W 1
 
-//!
-//! Define GPIO error codes that are returned by am_hal_gpio_pinconfig().
-//!
-enum am_hal_gpio_pincfgerr
-{
-    AM_HAL_GPIO_ERR_PULLUP      = (AM_HAL_STATUS_MODULE_SPECIFIC_START + 0x100),
-    AM_HAL_GPIO_ERR_PULLDOWN,
-    AM_HAL_GPIO_ERR_PWRSW,
-    AM_HAL_GPIO_ERR_INVCE,
-    AM_HAL_GPIO_ERR_INVCEPIN,
-    AM_HAL_GPIO_ERR_PULLUPENUM
-};
+    //!
+    //! Define GPIO error codes that are returned by am_hal_gpio_pinconfig().
+    //!
+    enum am_hal_gpio_pincfgerr
+    {
+        AM_HAL_GPIO_ERR_PULLUP = (AM_HAL_STATUS_MODULE_SPECIFIC_START + 0x100),
+        AM_HAL_GPIO_ERR_PULLDOWN,
+        AM_HAL_GPIO_ERR_PWRSW,
+        AM_HAL_GPIO_ERR_INVCE,
+        AM_HAL_GPIO_ERR_INVCEPIN,
+        AM_HAL_GPIO_ERR_PULLUPENUM
+    };
 
-//*****************************************************************************
-//
-// Globals
-//
-//*****************************************************************************
-//*****************************************************************************
-//  Define some common GPIO pin configurations.
-//*****************************************************************************
-//! Basics
-extern const am_hal_gpio_pincfg_t g_AM_HAL_GPIO_DISABLE;
-extern const am_hal_gpio_pincfg_t g_AM_HAL_GPIO_TRISTATE;
+    //*****************************************************************************
+    //
+    // Globals
+    //
+    //*****************************************************************************
+    //*****************************************************************************
+    //  Define some common GPIO pin configurations.
+    //*****************************************************************************
+    //! Basics
+    extern const am_hal_gpio_pincfg_t g_AM_HAL_GPIO_DISABLE;
+    extern const am_hal_gpio_pincfg_t g_AM_HAL_GPIO_TRISTATE;
 
-//! Input variations
-extern const am_hal_gpio_pincfg_t g_AM_HAL_GPIO_INPUT;
-//! Input with various pullups (weak, 1.5K, 6K, 12K, 24K)
-extern const am_hal_gpio_pincfg_t g_AM_HAL_GPIO_INPUT_PULLUP;
-extern const am_hal_gpio_pincfg_t g_AM_HAL_GPIO_INPUT_PULLUP_1_5;
-extern const am_hal_gpio_pincfg_t g_AM_HAL_GPIO_INPUT_PULLUP_6;
-extern const am_hal_gpio_pincfg_t g_AM_HAL_GPIO_INPUT_PULLUP_12;
-extern const am_hal_gpio_pincfg_t g_AM_HAL_GPIO_INPUT_PULLUP_24;
+    //! Input variations
+    extern const am_hal_gpio_pincfg_t g_AM_HAL_GPIO_INPUT;
+    //! Input with various pullups (weak, 1.5K, 6K, 12K, 24K)
+    extern const am_hal_gpio_pincfg_t g_AM_HAL_GPIO_INPUT_PULLUP;
+    extern const am_hal_gpio_pincfg_t g_AM_HAL_GPIO_INPUT_PULLUP_1_5;
+    extern const am_hal_gpio_pincfg_t g_AM_HAL_GPIO_INPUT_PULLUP_6;
+    extern const am_hal_gpio_pincfg_t g_AM_HAL_GPIO_INPUT_PULLUP_12;
+    extern const am_hal_gpio_pincfg_t g_AM_HAL_GPIO_INPUT_PULLUP_24;
 
-//! Output variations
-extern const am_hal_gpio_pincfg_t g_AM_HAL_GPIO_OUTPUT;
-extern const am_hal_gpio_pincfg_t g_AM_HAL_GPIO_OUTPUT_4;
-extern const am_hal_gpio_pincfg_t g_AM_HAL_GPIO_OUTPUT_8;
-extern const am_hal_gpio_pincfg_t g_AM_HAL_GPIO_OUTPUT_12;
-extern const am_hal_gpio_pincfg_t g_AM_HAL_GPIO_OUTPUT_WITH_READ;
+    //! Output variations
+    extern const am_hal_gpio_pincfg_t g_AM_HAL_GPIO_OUTPUT;
+    extern const am_hal_gpio_pincfg_t g_AM_HAL_GPIO_OUTPUT_4;
+    extern const am_hal_gpio_pincfg_t g_AM_HAL_GPIO_OUTPUT_8;
+    extern const am_hal_gpio_pincfg_t g_AM_HAL_GPIO_OUTPUT_12;
+    extern const am_hal_gpio_pincfg_t g_AM_HAL_GPIO_OUTPUT_WITH_READ;
 
-//*****************************************************************************
-//
-// Function pointer type for GPIO interrupt handlers.
-//
-//*****************************************************************************
-typedef void (*am_hal_gpio_handler_t)(void);
+    //*****************************************************************************
+    //
+    // Function pointer type for GPIO interrupt handlers.
+    //
+    //*****************************************************************************
+    typedef void (*am_hal_gpio_handler_t)(void);
 
-//*****************************************************************************
-//
-//! @brief Configure an Apollo3 pin.
-//!
-//! @param ui32Pin     - pin number to be configured.
-//! @param ui32GpioCfg - Contains multiple descriptor fields.
-//!
-//! This function configures a pin according to the descriptor parameters as
-//! passed in sPinCfg.  All parameters are validated with regard to each
-//! other and according to the requested function.  Once the parameters and
-//! settings have been confirmed, the pin is configured accordingly.
-//!
-//! @return Status.
-//
-//*****************************************************************************
-extern uint32_t am_hal_gpio_pinconfig(uint32_t ui32Pin,
-                                      am_hal_gpio_pincfg_t sPincfg);
+    //*****************************************************************************
+    //
+    //! @brief Configure an Apollo3 pin.
+    //!
+    //! @param ui32Pin     - pin number to be configured.
+    //! @param ui32GpioCfg - Contains multiple descriptor fields.
+    //!
+    //! This function configures a pin according to the descriptor parameters as
+    //! passed in sPinCfg.  All parameters are validated with regard to each
+    //! other and according to the requested function.  Once the parameters and
+    //! settings have been confirmed, the pin is configured accordingly.
+    //!
+    //! @return Status.
+    //
+    //*****************************************************************************
+    extern uint32_t am_hal_gpio_pinconfig(uint32_t ui32Pin,
+                                          am_hal_gpio_pincfg_t sPincfg);
 
-//*****************************************************************************
-//
-//! @brief Configure specified pins for FAST GPIO operation.
-//!
-//! @param ui64PinMask - a mask specifying up to 8 pins to be configured and
-//!               used for FAST GPIO (only bits 0-49 are valid).
-//! @param bfGpioCfg - The GPIO configuration (same as am_hal_gpio_pinconfig()).
-//!               All of the pins specified by ui64PinMask will be set to this
-//!               configuration.
-//! @param ui32Masks - If NULL, not used.  Otherwise if provided, an array to
-//!                 receive two 32-bit values, per pin, of the SET and CLEAR
-//!                 masks that can be used for the BBSETCLEAR register.
-//!                 The two 32-bit values will be placed at incremental indexes.
-//!                 For example, say pin numbers 5 and 19 are indicated in the
-//!                 mask, and an array pointer is provided in ui32Masks.  This
-//!                 array must be allocated by the caller to be at least 4 wds.
-//!                     ui32Masks[0] = the set   mask used for pin 5.
-//!                     ui32Masks[1] = the clear mask used for pin 5.
-//!                     ui32Masks[2] = the set   mask used for pin 19.
-//!                     ui32Masks[3] = the clear mask used for pin 19.
-//!
-//! @return Status.
-//!
-//! Fast GPIO helper macros:
-//!     am_hal_gpio_fastgpio_set(n) - Sets the value for pin number 'n'.
-//!     am_hal_gpio_fastgpio_clr(n) - Clear the value for pin number 'n'.
-//!
-//!     am_hal_gpio_fastgpio_enable(n)  - Enable Fast GPIO on pin 'n'.
-//!     am_hal_gpio_fastgpio_disable(n) - Disable Fast GPIO on pin 'n'.
-//!
-//!     Note - The enable and disable macros assume the pin has already been
-//!     configured. Once disabled, the state of the pin will revert to the
-//!     state of the normal GPIO configuration for that pin.
-//!
-//! NOTES on pin configuration:
-//! - To avoid glitches on the pin, it is strongly recommended that before
-//    calling am_hal_gpio_fast_pinconfig() that am_hal_gpio_fastgpio_disable()
-//!   first be called to make sure that Fast GPIO is disabled before config.
-//! - If the state of the pin is important, preset the value of the pin to the
-//!   desired value BEFORE calling am_hal_gpio_fast_pinconfig().  The set and
-//!   clear macros shown above can be used for this purpose.
-//!
-//! NOTES on general use of Fast GPIO:
-//! Fast GPIO input or output will not work if the pin is configured as
-//! tristate.  The overloaded OUTPUT ENABLE control is used for enabling both
-//! modes, so Apollo3 logic specifically disallows Fast GPIO input or output
-//! when the pin is configured for tristate mode.
-//! Fast GPIO input can be used for pushpull, opendrain, or disable modes.
-//!
-//! Fast GPIO pin groupings:
-//! The FaST GPIO pins are grouped across a matrix of pins.  Each
-//! row of pins is controlled by a single data bit.
-//!
-//! Referring to the below chart:
-//!  If pin 35 were configured for Fast GPIO output, it would be set
-//!  when bit3 of BBSETCLEAR.SET was written with a 1.
-//!  It would be cleared when bit3 of BBSETCLEAR.CLEAR was written with 1.
-//!
-//! Note that if all the pins in a row were configured for Fast GPIO output,
-//! all the pins would respond to set/clear.
-//!
-//! Input works in a similar fashion.
-//!
-//!     BIT   PIN controlled
-//!     ---  ---------------------------
-//!      0     0   8  16  24  32  40  48
-//!      1     1   9  17  25  33  41  49
-//!      2     2  10  18  26  34  42
-//!      3     3  11  19  27  35  43
-//!      4     4  12  20  28  36  44
-//!      5     5  13  21  29  37  45
-//!      6     6  14  22  30  38  46
-//!      7     7  15  23  31  39  47
-//!
-//
-//*****************************************************************************
-extern uint32_t am_hal_gpio_fast_pinconfig(uint64_t ui64PinMask,
-                                           am_hal_gpio_pincfg_t bfGpioCfg,
-                                           uint32_t ui32Masks[]);
+    //*****************************************************************************
+    //
+    //! @brief Configure specified pins for FAST GPIO operation.
+    //!
+    //! @param ui64PinMask - a mask specifying up to 8 pins to be configured and
+    //!               used for FAST GPIO (only bits 0-49 are valid).
+    //! @param bfGpioCfg - The GPIO configuration (same as am_hal_gpio_pinconfig()).
+    //!               All of the pins specified by ui64PinMask will be set to this
+    //!               configuration.
+    //! @param ui32Masks - If NULL, not used.  Otherwise if provided, an array to
+    //!                 receive two 32-bit values, per pin, of the SET and CLEAR
+    //!                 masks that can be used for the BBSETCLEAR register.
+    //!                 The two 32-bit values will be placed at incremental indexes.
+    //!                 For example, say pin numbers 5 and 19 are indicated in the
+    //!                 mask, and an array pointer is provided in ui32Masks.  This
+    //!                 array must be allocated by the caller to be at least 4 wds.
+    //!                     ui32Masks[0] = the set   mask used for pin 5.
+    //!                     ui32Masks[1] = the clear mask used for pin 5.
+    //!                     ui32Masks[2] = the set   mask used for pin 19.
+    //!                     ui32Masks[3] = the clear mask used for pin 19.
+    //!
+    //! @return Status.
+    //!
+    //! Fast GPIO helper macros:
+    //!     am_hal_gpio_fastgpio_set(n) - Sets the value for pin number 'n'.
+    //!     am_hal_gpio_fastgpio_clr(n) - Clear the value for pin number 'n'.
+    //!
+    //!     am_hal_gpio_fastgpio_enable(n)  - Enable Fast GPIO on pin 'n'.
+    //!     am_hal_gpio_fastgpio_disable(n) - Disable Fast GPIO on pin 'n'.
+    //!
+    //!     Note - The enable and disable macros assume the pin has already been
+    //!     configured. Once disabled, the state of the pin will revert to the
+    //!     state of the normal GPIO configuration for that pin.
+    //!
+    //! NOTES on pin configuration:
+    //! - To avoid glitches on the pin, it is strongly recommended that before
+    //    calling am_hal_gpio_fast_pinconfig() that am_hal_gpio_fastgpio_disable()
+    //!   first be called to make sure that Fast GPIO is disabled before config.
+    //! - If the state of the pin is important, preset the value of the pin to the
+    //!   desired value BEFORE calling am_hal_gpio_fast_pinconfig().  The set and
+    //!   clear macros shown above can be used for this purpose.
+    //!
+    //! NOTES on general use of Fast GPIO:
+    //! Fast GPIO input or output will not work if the pin is configured as
+    //! tristate.  The overloaded OUTPUT ENABLE control is used for enabling both
+    //! modes, so Apollo3 logic specifically disallows Fast GPIO input or output
+    //! when the pin is configured for tristate mode.
+    //! Fast GPIO input can be used for pushpull, opendrain, or disable modes.
+    //!
+    //! Fast GPIO pin groupings:
+    //! The FaST GPIO pins are grouped across a matrix of pins.  Each
+    //! row of pins is controlled by a single data bit.
+    //!
+    //! Referring to the below chart:
+    //!  If pin 35 were configured for Fast GPIO output, it would be set
+    //!  when bit3 of BBSETCLEAR.SET was written with a 1.
+    //!  It would be cleared when bit3 of BBSETCLEAR.CLEAR was written with 1.
+    //!
+    //! Note that if all the pins in a row were configured for Fast GPIO output,
+    //! all the pins would respond to set/clear.
+    //!
+    //! Input works in a similar fashion.
+    //!
+    //!     BIT   PIN controlled
+    //!     ---  ---------------------------
+    //!      0     0   8  16  24  32  40  48
+    //!      1     1   9  17  25  33  41  49
+    //!      2     2  10  18  26  34  42
+    //!      3     3  11  19  27  35  43
+    //!      4     4  12  20  28  36  44
+    //!      5     5  13  21  29  37  45
+    //!      6     6  14  22  30  38  46
+    //!      7     7  15  23  31  39  47
+    //!
+    //
+    //*****************************************************************************
+    extern uint32_t am_hal_gpio_fast_pinconfig(uint64_t ui64PinMask,
+                                               am_hal_gpio_pincfg_t bfGpioCfg,
+                                               uint32_t ui32Masks[]);
 
-//*****************************************************************************
-//
-//! @brief Read GPIO.
-//!
-//! @param ui32Pin      - pin number to be read.
-//! @param eReadType    - State type to read.  One of:
-//!     AM_HAL_GPIO_INPUT_READ
-//!     AM_HAL_GPIO_OUTPUT_READ
-//!     AM_HAL_GPIO_ENABLE_READ
-//!
-//! This function reads a pin state as given by eReadType.
-//!
-//! @return Status.
-//
-//*****************************************************************************
-extern uint32_t am_hal_gpio_state_read(uint32_t ui32Pin,
-                                       am_hal_gpio_read_type_e eReadType,
-                                       uint32_t *pu32RetVal);
+    //*****************************************************************************
+    //
+    //! @brief Read GPIO.
+    //!
+    //! @param ui32Pin      - pin number to be read.
+    //! @param eReadType    - State type to read.  One of:
+    //!     AM_HAL_GPIO_INPUT_READ
+    //!     AM_HAL_GPIO_OUTPUT_READ
+    //!     AM_HAL_GPIO_ENABLE_READ
+    //!
+    //! This function reads a pin state as given by eReadType.
+    //!
+    //! @return Status.
+    //
+    //*****************************************************************************
+    extern uint32_t am_hal_gpio_state_read(uint32_t ui32Pin,
+                                           am_hal_gpio_read_type_e eReadType,
+                                           uint32_t *pu32RetVal);
 
-//*****************************************************************************
-//
-//! @brief Write GPIO.
-//!
-//! @param ui32Pin      - pin number to be read.
-//!
-//! @param eWriteType   - State type to write.  One of:
-//!     AM_HAL_GPIO_OUTPUT_SET              - Write a one to a GPIO.
-//!     AM_HAL_GPIO_OUTPUT_CLEAR            - Write a zero to a GPIO.
-//!     AM_HAL_GPIO_OUTPUT_TOGGLE           - Toggle the GPIO value.
-//!     The following two apply when output is set for TriState (OUTCFG==3).
-//!     AM_HAL_GPIO_OUTPUT_TRISTATE_ENABLE  - Enable  a tri-state GPIO.
-//!     AM_HAL_GPIO_OUTPUT_TRISTATE_DISABLE - Disable a tri-state GPIO.
-//!
-//! This function writes a GPIO value.
-//!
-//! @return Status.
-//!         Fails if the pad is not configured for GPIO (PADFNCSEL != 3).
-//
-//*****************************************************************************
-extern uint32_t am_hal_gpio_state_write(uint32_t ui32Pin,
-                                        am_hal_gpio_write_type_e eWriteType);
+    //*****************************************************************************
+    //
+    //! @brief Write GPIO.
+    //!
+    //! @param ui32Pin      - pin number to be read.
+    //!
+    //! @param eWriteType   - State type to write.  One of:
+    //!     AM_HAL_GPIO_OUTPUT_SET              - Write a one to a GPIO.
+    //!     AM_HAL_GPIO_OUTPUT_CLEAR            - Write a zero to a GPIO.
+    //!     AM_HAL_GPIO_OUTPUT_TOGGLE           - Toggle the GPIO value.
+    //!     The following two apply when output is set for TriState (OUTCFG==3).
+    //!     AM_HAL_GPIO_OUTPUT_TRISTATE_ENABLE  - Enable  a tri-state GPIO.
+    //!     AM_HAL_GPIO_OUTPUT_TRISTATE_DISABLE - Disable a tri-state GPIO.
+    //!
+    //! This function writes a GPIO value.
+    //!
+    //! @return Status.
+    //!         Fails if the pad is not configured for GPIO (PADFNCSEL != 3).
+    //
+    //*****************************************************************************
+    extern uint32_t am_hal_gpio_state_write(uint32_t ui32Pin,
+                                            am_hal_gpio_write_type_e eWriteType);
 
-//*****************************************************************************
-//
-//! @brief Enable GPIO interrupts.
-//!
-//! @param ui64InterruptMask - Mask of GPIO interrupts to enable.
-//! Only bits 0-49 are valid in the mask.
-//!
-//! @return Status.
-//!         Fails if any bit above bit49 is set in ui64InterruptMask.
-//
-//*****************************************************************************
-extern uint32_t am_hal_gpio_interrupt_enable(uint64_t ui64InterruptMask);
+    //*****************************************************************************
+    //
+    //! @brief Enable GPIO interrupts.
+    //!
+    //! @param ui64InterruptMask - Mask of GPIO interrupts to enable.
+    //! Only bits 0-49 are valid in the mask.
+    //!
+    //! @return Status.
+    //!         Fails if any bit above bit49 is set in ui64InterruptMask.
+    //
+    //*****************************************************************************
+    extern uint32_t am_hal_gpio_interrupt_enable(uint64_t ui64InterruptMask);
 
-//*****************************************************************************
-//
-//! @brief Disable GPIO interrupts.
-//!
-//! @param ui64InterruptMask - Mask of GPIO interrupts to disable.
-//! Only bits 0-49 are valid in the mask.
-//!
-//! @return Status.
-//!         Fails if any bit above bit49 is set in ui64InterruptMask.
-//
-//*****************************************************************************
-extern uint32_t am_hal_gpio_interrupt_disable(uint64_t ui64InterruptMask);
+    //*****************************************************************************
+    //
+    //! @brief Disable GPIO interrupts.
+    //!
+    //! @param ui64InterruptMask - Mask of GPIO interrupts to disable.
+    //! Only bits 0-49 are valid in the mask.
+    //!
+    //! @return Status.
+    //!         Fails if any bit above bit49 is set in ui64InterruptMask.
+    //
+    //*****************************************************************************
+    extern uint32_t am_hal_gpio_interrupt_disable(uint64_t ui64InterruptMask);
 
-//*****************************************************************************
-//
-//! @brief Clear GPIO interrupts.
-//!
-//! @param ui64InterruptMask - Mask of GPIO interrupts to be cleared.
-//! Only bits 0-49 are valid in the mask.
-//!
-//! @return Status.
-//!         Fails if any bit above bit49 is set in ui64InterruptMask.
-//
-//*****************************************************************************
-extern uint32_t am_hal_gpio_interrupt_clear(uint64_t ui64InterruptMask);
+    //*****************************************************************************
+    //
+    //! @brief Clear GPIO interrupts.
+    //!
+    //! @param ui64InterruptMask - Mask of GPIO interrupts to be cleared.
+    //! Only bits 0-49 are valid in the mask.
+    //!
+    //! @return Status.
+    //!         Fails if any bit above bit49 is set in ui64InterruptMask.
+    //
+    //*****************************************************************************
+    extern uint32_t am_hal_gpio_interrupt_clear(uint64_t ui64InterruptMask);
 
-//*****************************************************************************
-//
-//! @brief Get GPIO interrupt status.
-//!
-//! @param bEnabledOnly - Return status only for currently enabled interrupts.
-//!
-//! @param pui64IntStatus - 64-bit variable to return a bitmask of the status
-//! of the interrupts.
-//!
-//! @return Status.
-//!         Fails if pui64IntStatus is NULL.
-//
-//*****************************************************************************
-extern uint32_t am_hal_gpio_interrupt_status_get(bool bEnabledOnly,
-                                                 uint64_t *pui64IntStatus);
+    //*****************************************************************************
+    //
+    //! @brief Get GPIO interrupt status.
+    //!
+    //! @param bEnabledOnly - Return status only for currently enabled interrupts.
+    //!
+    //! @param pui64IntStatus - 64-bit variable to return a bitmask of the status
+    //! of the interrupts.
+    //!
+    //! @return Status.
+    //!         Fails if pui64IntStatus is NULL.
+    //
+    //*****************************************************************************
+    extern uint32_t am_hal_gpio_interrupt_status_get(bool bEnabledOnly,
+                                                     uint64_t *pui64IntStatus);
 
-//*****************************************************************************
-//
-//! @brief GPIO interrupt service routine registration.
-//!
-//! @param ui32GPIONumber - GPIO number (0-49) to be registered.
-//!
-//! @param pfnHandler - Function pointer to the callback.
-//!
-//! @return Status.
-//!         Fails if pfnHandler is NULL or ui32GPIONumber > 49.
-//
-//*****************************************************************************
-extern uint32_t am_hal_gpio_interrupt_register(uint32_t ui32GPIONumber,
-                                               am_hal_gpio_handler_t pfnHandler);
+    //*****************************************************************************
+    //
+    //! @brief GPIO interrupt service routine registration.
+    //!
+    //! @param ui32GPIONumber - GPIO number (0-49) to be registered.
+    //!
+    //! @param pfnHandler - Function pointer to the callback.
+    //!
+    //! @return Status.
+    //!         Fails if pfnHandler is NULL or ui32GPIONumber > 49.
+    //
+    //*****************************************************************************
+    extern uint32_t am_hal_gpio_interrupt_register(uint32_t ui32GPIONumber,
+                                                   am_hal_gpio_handler_t pfnHandler);
 
-//*****************************************************************************
-//
-// GPIO interrupt service routine.
-//! @brief GPIO interrupt service routine registration.
-//!
-//! @param ui64Status - Mask of the interrupt(s) to be serviced.  This mask is
-//! typically obtained via a call to am_hal_gpio_interrupt_status_get().
-//!
-//! The intended use is that the application first registers a handler for a
-//! particular GPIO via am_hal_gpio_interrupt_register(), and to supply the
-//! main ISR, am_gpio_isr().
-//!
-//! On a GPIO interrupt, am_gpio_isr() calls am_hal_gpio_interrupt_status_get()
-//! and provides the return value to this function.
-//!
-//! In the event that multiple GPIO interrupts are active, the corresponding
-//! interrupt handlers will be called in numerical order by GPIO number
-//! starting with the lowest GPIO number.
-//!
-//! @return Status.
-//!         AM_HAL_STATUS_INVALID_OPERATION if no handler had been registered
-//!             for any of the GPIOs that caused the interrupt.
-//!         AM_HAL_STATUS_OUT_OF_RANGE if any bit above bit49 is set.
-//!         AM_HAL_STATUS_FAIL if ui64Status is 0.
-//!         AM_HAL_STATUS_SUCCESS otherwise.
-//
-//*****************************************************************************
-extern uint32_t am_hal_gpio_interrupt_service(uint64_t ui64Status);
-
+    //*****************************************************************************
+    //
+    // GPIO interrupt service routine.
+    //! @brief GPIO interrupt service routine registration.
+    //!
+    //! @param ui64Status - Mask of the interrupt(s) to be serviced.  This mask is
+    //! typically obtained via a call to am_hal_gpio_interrupt_status_get().
+    //!
+    //! The intended use is that the application first registers a handler for a
+    //! particular GPIO via am_hal_gpio_interrupt_register(), and to supply the
+    //! main ISR, am_gpio_isr().
+    //!
+    //! On a GPIO interrupt, am_gpio_isr() calls am_hal_gpio_interrupt_status_get()
+    //! and provides the return value to this function.
+    //!
+    //! In the event that multiple GPIO interrupts are active, the corresponding
+    //! interrupt handlers will be called in numerical order by GPIO number
+    //! starting with the lowest GPIO number.
+    //!
+    //! @return Status.
+    //!         AM_HAL_STATUS_INVALID_OPERATION if no handler had been registered
+    //!             for any of the GPIOs that caused the interrupt.
+    //!         AM_HAL_STATUS_OUT_OF_RANGE if any bit above bit49 is set.
+    //!         AM_HAL_STATUS_FAIL if ui64Status is 0.
+    //!         AM_HAL_STATUS_SUCCESS otherwise.
+    //
+    //*****************************************************************************
+    extern uint32_t am_hal_gpio_interrupt_service(uint64_t ui64Status);
 
 //*****************************************************************************
 //
@@ -604,21 +601,20 @@ extern uint32_t am_hal_gpio_interrupt_service(uint64_t ui64Status);
 //!
 //
 //*****************************************************************************
-#define am_hal_gpio_input_read(n)       (                                                                                                   \
-        (AM_REGVAL( (AM_REGADDR(GPIO, RDA) + (((uint32_t)(n) & 0x20) >> 3)) ) >>                /* Read appropriate register */             \
-          ((uint32_t)(n) & 0x1F) )      &                                                       /* Shift by appropriate number of bits */   \
-         ((uint32_t)0x1) )                                                                      /* Mask out the LSB */
+#define am_hal_gpio_input_read(n) (                                                                                \
+    (AM_REGVAL((AM_REGADDR(GPIO, RDA) + (((uint32_t)(n)&0x20) >> 3))) >> /* Read appropriate register */           \
+     ((uint32_t)(n)&0x1F)) &                                             /* Shift by appropriate number of bits */ \
+    ((uint32_t)0x1))                                                     /* Mask out the LSB */
 
-#define am_hal_gpio_output_read(n)      (                                                                                                   \
-        (AM_REGVAL( (AM_REGADDR(GPIO, WTA) + (((uint32_t)(n) & 0x20) >> 3)) ) >>                /* Read appropriate register */             \
-          ((uint32_t)(n) & 0x1F) )      &                                                       /* Shift by appropriate number of bits */   \
-         ((uint32_t)0x1) )                                                                      /* Mask out the LSB */
+#define am_hal_gpio_output_read(n) (                                                                               \
+    (AM_REGVAL((AM_REGADDR(GPIO, WTA) + (((uint32_t)(n)&0x20) >> 3))) >> /* Read appropriate register */           \
+     ((uint32_t)(n)&0x1F)) &                                             /* Shift by appropriate number of bits */ \
+    ((uint32_t)0x1))                                                     /* Mask out the LSB */
 
-#define am_hal_gpio_enable_read(n)      (                                                                                                   \
-        (AM_REGVAL( (AM_REGADDR(GPIO, ENA) + (((uint32_t)(n) & 0x20) >> 3)) ) >>                /* Read appropriate register */             \
-          ((uint32_t)(n) & 0x1F) )      &                                                       /* Shift by appropriate number of bits */   \
-         ((uint32_t)0x1) )                                                                      /* Mask out the LSB */
-
+#define am_hal_gpio_enable_read(n) (                                                                               \
+    (AM_REGVAL((AM_REGADDR(GPIO, ENA) + (((uint32_t)(n)&0x20) >> 3))) >> /* Read appropriate register */           \
+     ((uint32_t)(n)&0x1F)) &                                             /* Shift by appropriate number of bits */ \
+    ((uint32_t)0x1))                                                     /* Mask out the LSB */
 
 //*****************************************************************************
 //
@@ -649,51 +645,42 @@ extern uint32_t am_hal_gpio_interrupt_service(uint64_t ui64Status);
 //
 // Note - these macros use byte-oriented addressing.
 //
-#define am_hal_gpio_output_clear(n)                                                 \
-    ((*((volatile uint32_t *)                                                       \
-    ((AM_REGADDR(GPIO, WTCA) + (((uint32_t)(n) & 0x20) >> 3))))) =                  \
-     ((uint32_t) 0x1 << ((uint32_t)(n) % 32)))
+#define am_hal_gpio_output_clear(n)                                                       \
+    ((*((volatile uint32_t *)((AM_REGADDR(GPIO, WTCA) + (((uint32_t)(n)&0x20) >> 3))))) = \
+         ((uint32_t)0x1 << ((uint32_t)(n) % 32)))
 
-#define am_hal_gpio_output_set(n)                                                   \
-    ((*((volatile uint32_t *)                                                       \
-    ((AM_REGADDR(GPIO, WTSA) + (((uint32_t)(n) & 0x20) >> 3))))) =                  \
-     ((uint32_t) 0x1 << ((uint32_t)(n) % 32)))
+#define am_hal_gpio_output_set(n)                                                         \
+    ((*((volatile uint32_t *)((AM_REGADDR(GPIO, WTSA) + (((uint32_t)(n)&0x20) >> 3))))) = \
+         ((uint32_t)0x1 << ((uint32_t)(n) % 32)))
 
-#define am_hal_gpio_output_toggle(n)                                                \
-    if ( 1 )                                                                        \
-    {                                                                               \
-        AM_CRITICAL_BEGIN                                                           \
-        ((*((volatile uint32_t *)                                                   \
-        ((AM_REGADDR(GPIO, WTA) + (((uint32_t)(n) & 0x20) >> 3))))) ^=              \
-         ((uint32_t) 0x1 << ((uint32_t)(n) % 32)));                                 \
-        AM_CRITICAL_END                                                             \
+#define am_hal_gpio_output_toggle(n)                                                                           \
+    if (1)                                                                                                     \
+    {                                                                                                          \
+        AM_CRITICAL_BEGIN((*((volatile uint32_t *)((AM_REGADDR(GPIO, WTA) + (((uint32_t)(n)&0x20) >> 3))))) ^= \
+                          ((uint32_t)0x1 << ((uint32_t)(n) % 32)));                                            \
+        AM_CRITICAL_END                                                                                        \
     }
 
-#define am_hal_gpio_output_tristate_disable(n)                                      \
-    ((*((volatile uint32_t *)                                                       \
-     ((AM_REGADDR(GPIO, ENCA) + (((uint32_t)(n) & 0x20) >> 3))))) =                 \
-      ((uint32_t) 0x1 << ((uint32_t)(n) % 32)))
+#define am_hal_gpio_output_tristate_disable(n)                                            \
+    ((*((volatile uint32_t *)((AM_REGADDR(GPIO, ENCA) + (((uint32_t)(n)&0x20) >> 3))))) = \
+         ((uint32_t)0x1 << ((uint32_t)(n) % 32)))
 
-#define am_hal_gpio_output_tristate_enable(n)                                       \
-    ((*((volatile uint32_t *)                                                       \
-     ((AM_REGADDR(GPIO, ENSA) + (((uint32_t)(n) & 0x20) >> 3))))) =                 \
-      ((uint32_t) 0x1 << ((uint32_t)(n) % 32)))
+#define am_hal_gpio_output_tristate_enable(n)                                             \
+    ((*((volatile uint32_t *)((AM_REGADDR(GPIO, ENSA) + (((uint32_t)(n)&0x20) >> 3))))) = \
+         ((uint32_t)0x1 << ((uint32_t)(n) % 32)))
 
-#define am_hal_gpio_output_tristate_toggle(n)                                       \
-    if ( 1 )                                                                        \
-    {                                                                               \
-        AM_CRITICAL_BEGIN                                                           \
-        ((*((volatile uint32_t *)                                                   \
-         ((AM_REGADDR(GPIO, ENA) + (((uint32_t)(n) & 0x20) >> 3))))) ^=             \
-          ((uint32_t) 0x1 << ((uint32_t)(n) % 32)));                                \
-        AM_CRITICAL_END                                                             \
+#define am_hal_gpio_output_tristate_toggle(n)                                                                  \
+    if (1)                                                                                                     \
+    {                                                                                                          \
+        AM_CRITICAL_BEGIN((*((volatile uint32_t *)((AM_REGADDR(GPIO, ENA) + (((uint32_t)(n)&0x20) >> 3))))) ^= \
+                          ((uint32_t)0x1 << ((uint32_t)(n) % 32)));                                            \
+        AM_CRITICAL_END                                                                                        \
     }
-
 
 //
 // Define Fast GPIO enable and disable.
 //
-#define am_hal_gpio_fastgpio_enable(n)  am_hal_gpio_output_tristate_enable(n)
+#define am_hal_gpio_fastgpio_enable(n) am_hal_gpio_output_tristate_enable(n)
 #define am_hal_gpio_fastgpio_disable(n) am_hal_gpio_output_tristate_disable(n)
 
 //
@@ -702,20 +689,19 @@ extern uint32_t am_hal_gpio_interrupt_service(uint64_t ui64Status);
 // Note - these macros are most efficient if 'n' is a constant value, and
 //        of course when compiled with -O3.
 //
-#define am_hal_gpio_fastgpio_set(n)     (APBDMA->BBSETCLEAR = _VAL2FLD(APBDMA_BBSETCLEAR_SET,   (1 << (n & 0x7))))
-#define am_hal_gpio_fastgpio_clr(n)     (APBDMA->BBSETCLEAR = _VAL2FLD(APBDMA_BBSETCLEAR_CLEAR, (1 << (n & 0x7))))
-#define am_hal_gpio_fastgpio_setmsk(m)  (APBDMA->BBSETCLEAR = _VAL2FLD(APBDMA_BBSETCLEAR_SET, m))
-#define am_hal_gpio_fastgpio_clrmsk(m)  (APBDMA->BBSETCLEAR = _VAL2FLD(APBDMA_BBSETCLEAR_CLEAR, m))
-#define am_hal_gpio_fastgpio_wrval(val) (APBDMA->BBSETCLEAR =               \
-                                (_VAL2FLD(APBDMA_BBSETCLEAR_SET, val)   |   \
-                                 _VAL2FLD(APBDMA_BBSETCLEAR_CLEAR, val ^ 0xFF)))
-
+#define am_hal_gpio_fastgpio_set(n) (APBDMA->BBSETCLEAR = _VAL2FLD(APBDMA_BBSETCLEAR_SET, (1 << (n & 0x7))))
+#define am_hal_gpio_fastgpio_clr(n) (APBDMA->BBSETCLEAR = _VAL2FLD(APBDMA_BBSETCLEAR_CLEAR, (1 << (n & 0x7))))
+#define am_hal_gpio_fastgpio_setmsk(m) (APBDMA->BBSETCLEAR = _VAL2FLD(APBDMA_BBSETCLEAR_SET, m))
+#define am_hal_gpio_fastgpio_clrmsk(m) (APBDMA->BBSETCLEAR = _VAL2FLD(APBDMA_BBSETCLEAR_CLEAR, m))
+#define am_hal_gpio_fastgpio_wrval(val) (APBDMA->BBSETCLEAR =                        \
+                                             (_VAL2FLD(APBDMA_BBSETCLEAR_SET, val) | \
+                                              _VAL2FLD(APBDMA_BBSETCLEAR_CLEAR, val ^ 0xFF)))
 
 #ifdef __cplusplus
 }
 #endif
 
-#endif  // AM_HAL_GPIO_H
+#endif // AM_HAL_GPIO_H
 
 //*****************************************************************************
 //

--- a/cores/arduino/ard_sup/Arduino.h
+++ b/cores/arduino/ard_sup/Arduino.h
@@ -77,6 +77,7 @@ extern "C"
 #include "ap3_uart.h"
 #include "ap3_analog.h"
 #include "ap3_clock_sources.h"
+#include "ap3_shift.h"
 #include "WMath.h"
 #include "WCharacter.h"
 

--- a/cores/arduino/ard_sup/ap3_shift.h
+++ b/cores/arduino/ard_sup/ap3_shift.h
@@ -1,0 +1,35 @@
+/*
+Copyright (c) 2019 SparkFun Electronics
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.
+*/
+
+#ifndef _AP3_SHIFT_H_
+#define _AP3_SHIFT_H_
+
+#include "Arduino.h"
+
+void shiftOut(uint8_t dataPin, uint8_t clockPin, uint8_t bitOrder, uint8_t val);
+uint8_t shiftIn(uint8_t dataPin, uint8_t clockPin, uint8_t bitOrder);
+
+void enableFastShift(uint8_t dataPin, uint8_t clockPin);
+void fastShiftOut(uint8_t dataPin, uint8_t clockPin, uint8_t bitOrder, uint8_t val);
+uint8_t fastShiftIn(uint8_t dataPin, uint8_t clockPin, uint8_t bitOrder);
+
+#endif // _AP3_SHIFT_H_

--- a/cores/arduino/ard_sup/gpio/ap3_shift.cpp
+++ b/cores/arduino/ard_sup/gpio/ap3_shift.cpp
@@ -1,0 +1,119 @@
+/*
+  ap3_shift taken from wiring_shift.c by David Mellis.
+  Original copyright notice below.
+
+  wiring_shift.c - shiftOut() function
+  Part of Arduino - http://www.arduino.cc/
+
+  Copyright (c) 2005-2006 David A. Mellis
+
+  This library is free software; you can redistribute it and/or
+  modify it under the terms of the GNU Lesser General Public
+  License as published by the Free Software Foundation; either
+  version 2.1 of the License, or (at your option) any later version.
+
+  This library is distributed in the hope that it will be useful,
+  but WITHOUT ANY WARRANTY; without even the implied warranty of
+  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+  Lesser General Public License for more details.
+
+  You should have received a copy of the GNU Lesser General
+  Public License along with this library; if not, write to the
+  Free Software Foundation, Inc., 59 Temple Place, Suite 330,
+  Boston, MA  02111-1307  USA
+*/
+
+#include "ap3_shift.h"
+
+uint8_t shiftIn(uint8_t dataPin, uint8_t clockPin, uint8_t bitOrder)
+{
+    uint8_t value = 0;
+
+    for (uint8_t i = 0; i < 8; ++i)
+    {
+        digitalWrite(clockPin, HIGH);
+        if (bitOrder == LSBFIRST)
+            value |= digitalRead(dataPin) << i;
+        else
+            value |= digitalRead(dataPin) << (7 - i);
+        digitalWrite(clockPin, LOW);
+    }
+    return value;
+}
+
+void shiftOut(uint8_t dataPin, uint8_t clockPin, uint8_t bitOrder, uint8_t val)
+{
+    for (uint8_t i = 0; i < 8; i++)
+    {
+        if (bitOrder == LSBFIRST)
+            digitalWrite(dataPin, !!(val & (1 << i)));
+        else
+            digitalWrite(dataPin, !!(val & (1 << (7 - i))));
+
+        digitalWrite(clockPin, HIGH);
+        digitalWrite(clockPin, LOW);
+    }
+}
+
+// Configure a pin to be used in fast mode
+void enableFastShift(uint8_t dataPin, uint8_t clockPin)
+{
+    uint8_t dataPadNumber = ap3_gpio_pin2pad(dataPin);
+    uint8_t clockPadNumber = ap3_gpio_pin2pad(clockPin);
+
+    am_hal_gpio_fastgpio_disable(dataPadNumber);
+    am_hal_gpio_fastgpio_clr(dataPadNumber);
+
+    am_hal_gpio_fastgpio_disable(clockPadNumber);
+    am_hal_gpio_fastgpio_clr(clockPadNumber);
+
+    am_hal_gpio_fast_pinconfig((uint64_t)0x1 << dataPadNumber |
+                                   (uint64_t)0x1 << clockPadNumber,
+                               g_AM_HAL_GPIO_OUTPUT_12, 0);
+}
+
+void fastShiftOut(uint8_t dataPin, uint8_t clockPin, uint8_t bitOrder, uint8_t val)
+{
+    uint8_t dataPadNumber = ap3_gpio_pin2pad(dataPin);
+    uint8_t clockPadNumber = ap3_gpio_pin2pad(clockPin);
+
+    for (uint8_t i = 0; i < 8; i++)
+    {
+        if (bitOrder == LSBFIRST)
+        {
+            if (val & (1 << i))
+                am_hal_gpio_fastgpio_set(dataPadNumber);
+            else
+                am_hal_gpio_fastgpio_clr(dataPadNumber);
+        }
+        else
+        {
+            if (val & (1 << (7 - i)))
+                am_hal_gpio_fastgpio_set(dataPadNumber);
+            else
+                am_hal_gpio_fastgpio_clr(dataPadNumber);
+        }
+
+        am_hal_gpio_fastgpio_set(clockPadNumber);
+        am_hal_gpio_fastgpio_clr(clockPadNumber);
+    }
+}
+
+uint8_t fastShiftIn(uint8_t dataPin, uint8_t clockPin, uint8_t bitOrder)
+{
+    uint8_t dataPadNumber = ap3_gpio_pin2pad(dataPin);
+    uint8_t clockPadNumber = ap3_gpio_pin2pad(clockPin);
+
+    uint8_t value = 0;
+
+    for (uint8_t i = 0; i < 8; ++i)
+    {
+        am_hal_gpio_fastgpio_set(clockPadNumber);
+        if (bitOrder == LSBFIRST)
+            value |= am_hal_gpio_fastgpio_read(dataPadNumber) << i;
+        else
+            value |= am_hal_gpio_fastgpio_read(dataPadNumber) << (7 - i);
+        am_hal_gpio_fastgpio_clr(clockPadNumber);
+    }
+    return value;
+}

--- a/libraries/Examples/examples/Advanced/fastShift/fastShift.ino
+++ b/libraries/Examples/examples/Advanced/fastShift/fastShift.ino
@@ -1,0 +1,50 @@
+/* 
+  fastShiftIn() / fastShiftOut()
+  By: Nathan Seidle
+  SparkFun Electronics
+  Date: July 8th, 2019
+  License: This code is public domain.
+
+  SparkFun labored with love to create this code. Feel like supporting open source hardware?
+  Buy a board from SparkFun! https://www.sparkfun.com/products/15376
+
+  This example shows how use the new fastShiftOut/In functions.
+*/
+
+//Can be any GPIO
+#define CLOCK_PIN 14
+#define DATA_PIN 27
+
+void setup()
+{
+  Serial.begin(9600);
+  Serial.println("SparkFun Fast Shiftout Example");
+
+  pinMode(CLOCK_PIN, OUTPUT);
+  pinMode(DATA_PIN, OUTPUT);
+
+  //enableBurstMode(); //Optional. Go to 96MHz. Roughly doubles the speed of shiftOut and fastShiftOut
+
+  //This is the standard shiftOut() method
+//    while (1)
+//    {
+//      shiftOut(DATA_PIN, CLOCK_PIN, LSBFIRST, 0x0F); //Without BurstMode shiftOut runs at ~610kHz
+//    }
+
+  //Example of new fastShiftOut() method
+
+  //Configure the pins that are to be used for Fast GPIO.
+  enableFastShift(DATA_PIN, CLOCK_PIN);
+  while (1)
+  {
+    fastShiftOut(DATA_PIN, CLOCK_PIN, LSBFIRST, 0x0F); //Without BurstMode fastShiftOut runs at 4MHz
+    //byte incoming = fastShiftIn(DATA_PIN, CLOCK_PIN, LSBFIRST); //Without BurstMode fastShiftIn runs at 3.5MHz
+  }
+}
+
+void loop()
+{
+
+}
+
+


### PR DESCRIPTION
Basic reference support for shiftIn/shiftOut as well as three new functions:

* enableFastShift() - Sets the proper bits in the am_hal_gpio_fast_pinconfig register
* fastShiftOut/fastShiftIn - Works on any GPIO

Using SPI hardware will always be better than fastGPIO but I wanted to make them available if wanted.