### PR TITLE
Rename seconds() to secs() to avoid collisions with sketch variables

### DIFF
--- a/cores/arduino/ard_sup/ap3_timing.h
+++ b/cores/arduino/ard_sup/ap3_timing.h
@@ -24,15 +24,15 @@ SOFTWARE.
 
 #include "Arduino.h"
 
-#define AP3_STIMER_FREQ_HZ  (3000000)
-#define AP3_STIMER_FREQ_KHZ (AP3_STIMER_FREQ_HZ/1000)
-#define AP3_STIMER_FREQ_MHZ (AP3_STIMER_FREQ_HZ/1000000)
+#define AP3_STIMER_FREQ_HZ (3000000)
+#define AP3_STIMER_FREQ_KHZ (AP3_STIMER_FREQ_HZ / 1000)
+#define AP3_STIMER_FREQ_MHZ (AP3_STIMER_FREQ_HZ / 1000000)
 
-unsigned long micros( void );
-unsigned long millis( void );
-unsigned long seconds( void );
-unsigned long systicks( void );
-unsigned long sysoverflows( void );
+unsigned long micros(void);
+unsigned long millis(void);
+unsigned long secs(void);
+unsigned long systicks(void);
+unsigned long sysoverflows(void);
 void delay(uint32_t ms);
 void delayMicroseconds(uint32_t us);
 

--- a/cores/arduino/ard_sup/timing/ap3_timing.cpp
+++ b/cores/arduino/ard_sup/timing/ap3_timing.cpp
@@ -24,48 +24,56 @@ SOFTWARE.
 volatile uint32_t ap3_stimer_overflows = 0x00;
 uint64_t ticks = 0;
 
-void _fill_ticks( void ){
+void _fill_ticks(void)
+{
     ticks = ap3_stimer_overflows;
     ticks <<= 32;
     ticks |= (am_hal_stimer_counter_get() & 0xFFFFFFFF);
 }
 
-unsigned long micros( void ){
+unsigned long micros(void)
+{
     _fill_ticks();
-    return (uint32_t)(ticks/AP3_STIMER_FREQ_MHZ);
+    return (uint32_t)(ticks / AP3_STIMER_FREQ_MHZ);
 }
 
-unsigned long millis( void ){
+unsigned long millis(void)
+{
     _fill_ticks();
-    return (uint32_t)(ticks/AP3_STIMER_FREQ_KHZ);
+    return (uint32_t)(ticks / AP3_STIMER_FREQ_KHZ);
 }
 
-unsigned long seconds( void ){
+unsigned long secs(void)
+{
     _fill_ticks();
-    return (uint32_t)(ticks/AP3_STIMER_FREQ_HZ);
+    return (uint32_t)(ticks / AP3_STIMER_FREQ_HZ);
 }
 
-unsigned long systicks( void ){
+unsigned long systicks(void)
+{
     return am_hal_stimer_counter_get();
 }
 
-unsigned long sysoverflows( void ){
+unsigned long sysoverflows(void)
+{
     return ap3_stimer_overflows;
 }
 
-void delay(uint32_t ms){
+void delay(uint32_t ms)
+{
     am_util_delay_ms(ms);
 }
 
-void delayMicroseconds(uint32_t us){
+void delayMicroseconds(uint32_t us)
+{
     am_util_delay_us(us);
 }
 
-extern "C" void am_stimer_isr(void){
-  am_hal_stimer_int_clear(AM_HAL_STIMER_INT_OVERFLOW);
-  ap3_stimer_overflows += 1;
-  // At the fastest rate (3MHz) the 64 bits of the stimer 
-  // along with this overflow counter can keep track of
-  // the time for ~ 195,000 years without wrapping to 0
+extern "C" void am_stimer_isr(void)
+{
+    am_hal_stimer_int_clear(AM_HAL_STIMER_INT_OVERFLOW);
+    ap3_stimer_overflows += 1;
+    // At the fastest rate (3MHz) the 64 bits of the stimer
+    // along with this overflow counter can keep track of
+    // the time for ~ 195,000 years without wrapping to 0
 }
-


### PR DESCRIPTION
'seconds' is common enough it collides with example sketches. 'secs' follows the micros and millis convention (roughly).