### PR TITLE
Add first wiki pages and update ACKNOWLEDGEMENTS.md

### DIFF
--- a/docs/ACKNOWLEDGEMENTS.md
+++ b/docs/ACKNOWLEDGEMENTS.md
@@ -9,5 +9,6 @@ Thank you to everyone who has contributed!
 Contributors
 ============
 * Jim Lindblom
+* Kenny Hora
 * Owen Lyke
 * Nathan Seidle


### PR DESCRIPTION
Added preliminary home page and software interrupts page to wiki, as a result of issue #34 in sparkfun/Ardunio_Apollo3. Add name to contributors list.