### PR TITLE
Move ADC channel selection out of variant files

### DIFF
--- a/cores/arduino/ard_sup/Arduino_defines.h
+++ b/cores/arduino/ard_sup/Arduino_defines.h
@@ -1,14 +1,12 @@
 
 
-
-
 // Constants
-#define LOW         (0x0)
-#define HIGH        (0x1)
+#define LOW (0x0)
+#define HIGH (0x1)
 
-#define CHANGE      (0x02)
-#define FALLING     (0x03)
-#define RISING      (0x04)
+#define CHANGE (0x02)
+#define FALLING (0x03)
+#define RISING (0x04)
 
 #define PI 3.1415926535897932384626433832795
 #define HALF_PI 1.5707963267948966192313216916398
@@ -17,6 +15,12 @@
 #define RAD_TO_DEG 57.295779513082320876798154814105
 #define EULER 2.718281828459045235360287471352
 
+//Special "pads" used by the ADC to select the special internal ADC channels
+#define ADC_DIFF0 100
+#define ADC_DIFF1 101
+#define ADC_INTERNAL_TEMP 102
+#define ADC_INTERNAL_VCC_DIV3 103
+#define ADC_INTERNAL_VSS 104
 
 // Functions
 // undefine stdlib's abs if encountered
@@ -43,4 +47,4 @@
 
 #define bit(b) (1UL << (b))
 
-#define digitalPinToInterrupt(P)   (P) // all apollo3 pads are interrupt capable
+#define digitalPinToInterrupt(P) (P) // all apollo3 pads are interrupt capable

--- a/cores/arduino/ard_sup/analog/ap3_analog.cpp
+++ b/cores/arduino/ard_sup/analog/ap3_analog.cpp
@@ -129,7 +129,17 @@ uint16_t analogRead(uint8_t pinNumber)
     am_hal_adc_sample_t Sample;
     uint32_t ui32NumSamples = 1;
 
-    uint8_t padNumber = ap3_gpio_pin2pad(pinNumber);
+    uint8_t padNumber;
+
+    if (pinNumber >= ADC_DIFF0 && pinNumber <= ADC_INTERNAL_VSS)
+    {
+        //Special handling of internal ADC channels
+        padNumber = pinNumber;
+    }
+    else
+    {
+        padNumber = ap3_gpio_pin2pad(pinNumber);
+    }
 
     //Look up configuration status based on pad number
     uint8_t indi;
@@ -292,18 +302,7 @@ ap3_err_t ap3_set_pin_to_analog(uint8_t pinNumber)
 
     uint8_t funcsel = 0;
     am_hal_gpio_pincfg_t pincfg = INPUT;
-
-    //Handle special ADC channels
-    if (pinNumber >= ADC_DIFF0 && pinNumber <= ADC_INTERNAL_VSS)
-    {
-        //Don't use the pin to pad lookup from the variant file
-        retval = ap3_analog_pad_funcsel(pinNumber, &funcsel);
-    }
-    else
-    {
-        //Normal pin lookup
-        retval = ap3_analog_pad_funcsel(ap3_gpio_pin2pad(pinNumber), &funcsel);
-    }
+    retval = ap3_analog_pad_funcsel(ap3_gpio_pin2pad(pinNumber), &funcsel);
 
     if (retval != AP3_OK)
     {

--- a/cores/arduino/ard_sup/ap3_analog_types.h
+++ b/cores/arduino/ard_sup/ap3_analog_types.h
@@ -28,7 +28,7 @@ SOFTWARE.
 
 enum EXTRA_ADC_PADS
 {
-    AP3_ADC_DIFF0_PAD = 51, //More than physical pads on Apollo3
+    AP3_ADC_DIFF0_PAD = 100, //More than physical pads on Apollo3
     AP3_ADC_DIFF1_PAD,
     AP3_ADC_TEMP_PAD,
     AP3_ADC_DIV3_PAD,

--- a/libraries/Examples/examples/Example4_analogRead/Example4_analogRead.ino
+++ b/libraries/Examples/examples/Example4_analogRead/Example4_analogRead.ino
@@ -13,7 +13,7 @@
 
   Feel like supporting open source hardware?
   Buy a board from SparkFun!
-  SparkFun Edge: https://www.sparkfun.com/products/15170
+  SparkFun Edge: https://www.sparkfun.com/artemis
 
   Hardware Connections:
   Upload code
@@ -30,7 +30,7 @@ void setup()
 
   pinMode(LED, OUTPUT);
 
-  //analogReadResolution(14); //Set resolution to 14 bit
+  analogReadResolution(14); //Set resolution to 14 bit
   //analogReadResolution(16); //Set resolution to 16 bit - will pad ADC output with two zeros
 }
 
@@ -38,29 +38,29 @@ void loop()
 {
   digitalWrite(LED, LOW);
 
-  int myValue1 = analogRead(A1); //Automatically sets pin to analog input
-  Serial.print("A1: ");
+  int myValue1 = analogRead(A3); //Automatically sets pin to analog input
+  Serial.print("A3: ");
   Serial.print(myValue1);
 
-  int internalTemp = analogRead(ADC_TEMP); //Read internal temp sensor. 3.8mV/C, +/-3C
-  Serial.print("\tinternalTemp: ");
-  Serial.print(internalTemp);
-
-  int vss = analogRead(ADC_VSS); //Read internal VSS
-  Serial.print("\tvss: ");
-  Serial.print(vss);
-
   //TODO enable battload
-  int div3 = analogRead(ADC_DIV3); //Read VCC across a 1/3 resistor divider
+  int div3 = analogRead(ADC_INTERNAL_VCC_DIV3); //Read VCC across a 1/3 resistor divider
   Serial.print("\tVCC/3: ");
   Serial.print(div3);
 
-  float vcc = (float)div3 * 6 / 1024.0; //Convert 1/3 VCC to VCC
+  float vcc = (float)div3 * 6 / 16384.0; //Convert 1/3 VCC to VCC
   Serial.print(" VCC: ");
   Serial.print(vcc, 2);
   Serial.print("V");
 
-  //pinMode(A4, OUTPUT); //Reset analog function to false.
+  int internalTempVoltage = analogRead(ADC_INTERNAL_TEMP); //Read internal temp sensor. 3.8mV/C, +/-3C
+  double internalTemp = internalTempVoltage * vcc / 16384.0; //Convert internal temp reading to voltage
+  internalTemp /= 0.0038; //Convert voltage to degrees C
+  Serial.print("\tinternalTemp: ");
+  Serial.print(internalTemp, 2);
+
+  int vss = analogRead(ADC_INTERNAL_VSS); //Read internal VSS (should be 0)
+  Serial.print("\tvss: ");
+  Serial.print(vss);
 
   Serial.println();
 

--- a/variants/SparkFun_BlackBoard_Artemis/config/variant.cpp
+++ b/variants/SparkFun_BlackBoard_Artemis/config/variant.cpp
@@ -25,43 +25,38 @@ SOFTWARE.
 const ap3_gpio_pad_t ap3_variant_pinmap[AP3_VARIANT_NUM_PINS] = {
     //~ = PWM, A = ADC
     //Apollo Pad,      //Silkscreen indicator - Pin functions
-    25,                //0 - ~RX1/SDA2/MISO2
-    24,                //1 - ~TX1/32kHz/SWO
-    35,                //2/A6 - ~A/TX1/I2SDAT/PDMCLK
-    4,                 //3 - ~RX1/SLINT
-    22,                //4 - ~PDMCLK/SWO
-    23,                //5 - ~I2SWCLK/CMPOUT
-    27,                //6 - ~SCL2/SCK2
-    28,                //7 - ~MOSI2/I2SWCLK
-    32,                //8/A8 - ~A/SCCIO
-    12,                //9/A9 - ~A/PDMCLK/TX1
-    13,                //10/A10 - ~A/I2SBCLK/RX1
-    7,                 //11 - ~MOSI0/CLKOUT
-    6,                 //12 - ~MISO0/SDA0/I2SDAT
-    5,                 //13 - ~LED/SCK0/SCL0
-    40,                //14 - SDA4/MISO4/RX1
-    39,                //15 - ~SCL4/SCK4/TX1
-    29,                //16/A0 - ~A/PDMDATA
-    11,                //17/A1 - ~A/PDMDATA
-    34,                //18/A2 - A/CMPRF2/PDMDATA
-    33,                //19/A3 - ~A/SWO/32kHz
-    16,                //20/A4 - A/TRIG0/SCCRST
-    31,                //21/A5 - ~A/SCCCLK
-    48,                //22 - ~TX0/SCL5/SCK5
-    49,                //23 - ~RX0/SDA5/MISO5
-    8,                 //24 - Solder pad, SCL1/SCK1/TX1/SCCLK
-    9,                 //25 - Solder pad, SDA1/MISO1/RX1/SCCIO
-    10,                //26 - Solder pad, MOSI1/TX1/PDMCLK
-    38,                //27 - Solder pad, MOSI3/TX1
-    42,                //28 - Solder pad, ~SCL3/SCK3/TX1
-    43,                //29 - Solder pad, ~SDA3/MISO3/RX1
-    36,                //30 - Not exposed, PDMDATA of Mic
-    37,                //31 - Not exposed, PDMCLK of Mic
-    AP3_ADC_DIFF0_PAD, //32 - Not a real pad, ADC_DIFF0
-    AP3_ADC_DIFF1_PAD, //33 - Not a real pad, ADC_DIFF1
-    AP3_ADC_TEMP_PAD,  //34 - Not a real pad, ADC_TEMP
-    AP3_ADC_DIV3_PAD,  //35 - Not a real pad, ADC_DIV3
-    AP3_ADC_VSS_PAD,   //36 - Not a real pad, ADC_VSS
+    25, //0 - ~RX1/SDA2/MISO2
+    24, //1 - ~TX1/32kHz/SWO
+    35, //2/A6 - ~A/TX1/I2SDAT/PDMCLK
+    4,  //3 - ~RX1/SLINT
+    22, //4 - ~PDMCLK/SWO
+    23, //5 - ~I2SWCLK/CMPOUT
+    27, //6 - ~SCL2/SCK2
+    28, //7 - ~MOSI2/I2SWCLK
+    32, //8/A8 - ~A/SCCIO
+    12, //9/A9 - ~A/PDMCLK/TX1
+    13, //10/A10 - ~A/I2SBCLK/RX1
+    7,  //11 - ~MOSI0/CLKOUT
+    6,  //12 - ~MISO0/SDA0/I2SDAT
+    5,  //13 - ~LED/SCK0/SCL0
+    40, //14 - SDA4/MISO4/RX1
+    39, //15 - ~SCL4/SCK4/TX1
+    29, //16/A0 - ~A/PDMDATA
+    11, //17/A1 - ~A/PDMDATA
+    34, //18/A2 - A/CMPRF2/PDMDATA
+    33, //19/A3 - ~A/SWO/32kHz
+    16, //20/A4 - A/TRIG0/SCCRST
+    31, //21/A5 - ~A/SCCCLK
+    48, //22 - ~TX0/SCL5/SCK5
+    49, //23 - ~RX0/SDA5/MISO5
+    8,  //24 - Solder pad, SCL1/SCK1/TX1/SCCLK
+    9,  //25 - Solder pad, SDA1/MISO1/RX1/SCCIO
+    10, //26 - Solder pad, MOSI1/TX1/PDMCLK
+    38, //27 - Solder pad, MOSI3/TX1
+    42, //28 - Solder pad, ~SCL3/SCK3/TX1
+    43, //29 - Solder pad, ~SDA3/MISO3/RX1
+    36, //30 - Not exposed, PDMDATA of Mic
+    37, //31 - Not exposed, PDMCLK of Mic
 };
 
 // Uart Definitions

--- a/variants/SparkFun_BlackBoard_Artemis/config/variant.h
+++ b/variants/SparkFun_BlackBoard_Artemis/config/variant.h
@@ -24,7 +24,7 @@ SOFTWARE.
 
 #include "Arduino.h"
 
-#define AP3_VARIANT_NUM_PINS (37)
+#define AP3_VARIANT_NUM_PINS (32)
 
 // Pin map declaration
 extern const ap3_gpio_pad_t ap3_variant_pinmap[AP3_VARIANT_NUM_PINS];
@@ -58,11 +58,6 @@ extern Uart Serial1;
 #define A8 8
 #define A9 9
 #define A10 10
-#define ADC_DIFF0 32 //Not legal pins. Used for pad lookup
-#define ADC_DIFF1 33
-#define ADC_TEMP 34
-#define ADC_DIV3 35
-#define ADC_VSS 36
 
 #define LED_BUILTIN 13
 

--- a/variants/SparkFun_BlackBoard_Artemis_ATP/config/variant.cpp
+++ b/variants/SparkFun_BlackBoard_Artemis_ATP/config/variant.cpp
@@ -70,15 +70,10 @@ const ap3_gpio_pad_t ap3_variant_pinmap[AP3_VARIANT_NUM_PINS] = {
     43,
     44,
     45,
-    46,
+    AP3_GPIO_PAD_UNUSED, //The one pad not broken out of the Apollo3 on the Artemis
     47,
     48,
     49,
-    AP3_ADC_DIFF0_PAD, //50 - Not a real pad, ADC_DIFF0
-    AP3_ADC_DIFF1_PAD, //51 - Not a real pad, ADC_DIFF1
-    AP3_ADC_TEMP_PAD,  //52 - Not a real pad, ADC_TEMP
-    AP3_ADC_DIV3_PAD,  //53 - Not a real pad, ADC_DIV3
-    AP3_ADC_VSS_PAD,   //54 - Not a real pad, ADC_VSS
 };
 
 // Uart Definitions

--- a/variants/SparkFun_BlackBoard_Artemis_ATP/config/variant.h
+++ b/variants/SparkFun_BlackBoard_Artemis_ATP/config/variant.h
@@ -24,7 +24,7 @@ SOFTWARE.
 
 #include "Arduino.h"
 
-#define AP3_VARIANT_NUM_PINS (55)
+#define AP3_VARIANT_NUM_PINS (50)
 
 // Pin map declaration
 extern const ap3_gpio_pad_t ap3_variant_pinmap[AP3_VARIANT_NUM_PINS];
@@ -57,12 +57,6 @@ extern Uart Serial1;
 #define A12 12
 #define A33 33
 #define A35 35
-
-#define ADC_DIFF0 50 //Not legal pins. Used for pad lookup
-#define ADC_DIFF1 51
-#define ADC_TEMP 52
-#define ADC_DIV3 53
-#define ADC_VSS 54
 
 #define LED_BUILTIN 5
 

--- a/variants/SparkFun_BlackBoard_Artemis_Nano/config/variant.cpp
+++ b/variants/SparkFun_BlackBoard_Artemis_Nano/config/variant.cpp
@@ -25,35 +25,30 @@ SOFTWARE.
 const ap3_gpio_pad_t ap3_variant_pinmap[AP3_VARIANT_NUM_PINS] = {
     //~ = PWM, A = ADC
     //Apollo Pad, //Silkscreen indicator
-    13,                //A0 - ~I2SBCLK/RX1
-    33,                //A1 - ~SWO/32kHz
-    11,                //A2 - ~PDMDATA
-    29,                //A3 - ~PDMDATA
-    18,                //4 - ~CMPIN1/SCCIO
-    31,                //A5 - ~SCCCLK
-    43,                //6 - ~SDA3/MISO3/RX1
-    42,                //7 - SCL3/SCK3/TX1
-    38,                //8 - MOSI3/RX1
-    39,                //9 - ~SCL4/SCK4/TX1
-    40,                //10 - SDA4/MISO4/RX1
-    5,                 //11 - ~SCL0/SCK0
-    7,                 //12 - ~MOSI0/CLKOUT
-    6,                 //13 - ~SDA0/MISO0/I2SDAT
-    35,                //A14 - ~TX1/I2SDAT/PDMCLK
-    32,                //A15 - ~SCCIO
-    12,                //A16 - ~PDMCLK/TX1
-    32,                //17 - ~SDA2/MISO3/RX1
-    12,                //18 - ~SCL2/SCK2
-    19,                //19 - ~Not exposed, Status LED
-    48,                //20 - Not exposed, TX0
-    49,                //21 - Not exposed, RX0
-    36,                //22 - Not exposed, PDMDATA of Mic
-    37,                //23 - Not exposed, PDMCLK of Mic
-    AP3_ADC_DIFF0_PAD, //24 - Not a real pad, ADC_DIFF0
-    AP3_ADC_DIFF1_PAD, //25 - Not a real pad, ADC_DIFF1
-    AP3_ADC_TEMP_PAD,  //26 - Not a real pad, ADC_TEMP
-    AP3_ADC_DIV3_PAD,  //27 - Not a real pad, ADC_DIV3
-    AP3_ADC_VSS_PAD,   //28 - Not a real pad, ADC_VSS
+    13, //A0 - ~I2SBCLK/RX1
+    33, //A1 - ~SWO/32kHz
+    11, //A2 - ~PDMDATA
+    29, //A3 - ~PDMDATA
+    18, //4 - ~CMPIN1/SCCIO
+    31, //A5 - ~SCCCLK
+    43, //6 - ~SDA3/MISO3/RX1
+    42, //7 - SCL3/SCK3/TX1
+    38, //8 - MOSI3/RX1
+    39, //9 - ~SCL4/SCK4/TX1
+    40, //10 - SDA4/MISO4/RX1
+    5,  //11 - ~SCL0/SCK0
+    7,  //12 - ~MOSI0/CLKOUT
+    6,  //13 - ~SDA0/MISO0/I2SDAT
+    35, //A14 - ~TX1/I2SDAT/PDMCLK
+    32, //A15 - ~SCCIO
+    12, //A16 - ~PDMCLK/TX1
+    32, //17 - ~SDA2/MISO3/RX1
+    12, //18 - ~SCL2/SCK2
+    19, //19 - ~Not exposed, Status LED
+    48, //20 - Not exposed, TX0
+    49, //21 - Not exposed, RX0
+    36, //22 - Not exposed, PDMDATA of Mic
+    37, //23 - Not exposed, PDMCLK of Mic
 };
 
 // Uart Definitions

--- a/variants/SparkFun_BlackBoard_Artemis_Nano/config/variant.h
+++ b/variants/SparkFun_BlackBoard_Artemis_Nano/config/variant.h
@@ -24,7 +24,7 @@ SOFTWARE.
 
 #include "Arduino.h"
 
-#define AP3_VARIANT_NUM_PINS (29)
+#define AP3_VARIANT_NUM_PINS (24)
 
 // Pin map declaration
 extern const ap3_gpio_pad_t ap3_variant_pinmap[AP3_VARIANT_NUM_PINS];


### PR DESCRIPTION
In normal course, general pins are converted to pads. With this commit any pin number over 99 is treated as a special internal ADC channel. These 'pins' are not converted to pads via ap3_gpio_pin2pad() (calls the board variant).

ADC works correctly. The analogRead was updated as well. Internal temp is now more accurately calculated. All variants updated.

This should fix issue #45.