### PR TITLE
Change UNUSED def to avoid compiler errors

### DIFF
--- a/cores/arduino/ard_sup/ap3_gpio.h
+++ b/cores/arduino/ard_sup/ap3_gpio.h
@@ -45,7 +45,7 @@ extern const am_hal_gpio_pincfg_t g_AM_HAL_GPIO_INPUT_PULLDOWN;
 #define AP3_GPIO_IS_VALID(pad) ((pad >= 0) && (pad < AP3_GPIO_MAX_PADS))
 
 extern ap3_gpio_pad_t ap3_gpio_pin2pad(ap3_gpio_pin_t pin);
-#define AP3_GPIO_PAD_UNUSED (-1)
+#define AP3_GPIO_PAD_UNUSED (255)
 
 #define AP3_GPIO_DEFAULT_PINCFG AP3_GPIO_PINCFG_NULL
 


### PR DESCRIPTION
A super simple PR, but I wanted to be sure this won't conflict with anything else.

255 = -1 in 8bit land so we should be fine assuming there is no logic testing for pin# > 0.