### PR TITLE
Small cleanup

### DIFF
--- a/libraries/SPI/src/SPI.cpp
+++ b/libraries/SPI/src/SPI.cpp
@@ -128,8 +128,9 @@ void SPIClass::end()
 static inline unsigned char __interruptsStatus(void) __attribute__((always_inline, unused));
 static inline unsigned char __interruptsStatus(void)
 {
-  // // See http://infocenter.arm.com/help/index.jsp?topic=/com.arm.doc.dui0497a/CHDBIBGJ.html
-  // return (__get_PRIMASK() ? 0 : 1);
+  // See http://infocenter.arm.com/help/index.jsp?topic=/com.arm.doc.dui0497a/CHDBIBGJ.html - Cortex-M0
+  // Equivalent Cortex-M3 http://infocenter.arm.com/help/topic/com.arm.doc.dui0552a/CHDBIBGJ.html
+  return (__get_PRIMASK() ? 0 : 1);
 }
 #endif
 
@@ -300,12 +301,15 @@ void SPIClass::_transfer(void *buf_out, void *buf_in, size_t count)
   }
 
   uint32_t retVal32 = 0;
-  if( iomTransfer.eDirection == AM_HAL_IOM_FULLDUPLEX ){
+  if (iomTransfer.eDirection == AM_HAL_IOM_FULLDUPLEX)
+  {
     retVal32 = am_hal_iom_spi_blocking_fullduplex(_handle, &iomTransfer);
-  }else{
+  }
+  else
+  {
     retVal32 = am_hal_iom_blocking_transfer(_handle, &iomTransfer);
   }
-   
+
   // if (retVal32 != 0)
   // {
   //   Serial.printf("got an error on _transfer: %d\n", retVal32);

--- a/libraries/SPI/src/SPI.h
+++ b/libraries/SPI/src/SPI.h
@@ -24,18 +24,15 @@
 #include "ap3_iomaster.h"
 
 // Give a warning if the variant did not define these symbols:
-#ifndef SS
-#warning "variant has no definition for pin number 'SS'"
-#endif  // SS
 #ifndef MOSI
 #warning "variant has no definition for pin number 'MOSI'"
-#endif  // MOSI
+#endif // MOSI
 #ifndef MISO
 #warning "variant has no definition for pin number 'MISO'"
-#endif  // MISO
-#ifndef CLK
-#warning "variant has no definition for pin number 'CLK'"
-#endif  // CLK
+#endif // MISO
+#ifndef SCK
+#warning "variant has no definition for pin number 'SCK'"
+#endif // SCK
 
 // SPI_HAS_TRANSACTION means SPI has
 //   - beginTransaction()
@@ -52,34 +49,43 @@
 #define SPI_MODE2 AM_HAL_IOM_SPI_MODE_2
 #define SPI_MODE3 AM_HAL_IOM_SPI_MODE_3
 
-typedef enum{
+typedef enum
+{
   ap3_spi_tx_only = 1,
   ap3_spi_rx_only = 2,
   ap3_spi_full_duplex = 3,
-}ap3_spi_duplex_e;
+} ap3_spi_duplex_e;
 
-class SPISettings {
-  public:
-  SPISettings(uint32_t clock, BitOrder bitOrder, uint8_t dataMode) {
-    if (__builtin_constant_p(clock)) {
+class SPISettings
+{
+public:
+  SPISettings(uint32_t clock, BitOrder bitOrder, uint8_t dataMode)
+  {
+    if (__builtin_constant_p(clock))
+    {
       init_AlwaysInline(clock, bitOrder, dataMode);
-    } else {
+    }
+    else
+    {
       init_MightInline(clock, bitOrder, dataMode);
     }
   }
 
   // Default speed set to 4MHz, SPI mode set to MODE 0 and Bit order set to MSB first.
-  SPISettings() {
-    init_AlwaysInline(4000000, MSBFIRST, SPI_MODE0); 
+  SPISettings()
+  {
+    init_AlwaysInline(4000000, MSBFIRST, SPI_MODE0);
   }
 
-  private:
-  public: // temporary
-  void init_MightInline(uint32_t clock, BitOrder bitOrder, uint8_t dataMode) {
+private:
+public: // temporary
+  void init_MightInline(uint32_t clock, BitOrder bitOrder, uint8_t dataMode)
+  {
     init_AlwaysInline(clock, bitOrder, dataMode);
   }
 
-  void init_AlwaysInline(uint32_t clock, BitOrder bitOrder, uint8_t dataMode) __attribute__((__always_inline__)) {
+  void init_AlwaysInline(uint32_t clock, BitOrder bitOrder, uint8_t dataMode) __attribute__((__always_inline__))
+  {
     this->clockFreq = clock;
     this->bitOrder = bitOrder;
     this->dataMode = (am_hal_iom_spi_mode_e)dataMode;
@@ -92,8 +98,9 @@ class SPISettings {
   friend class SPIClass;
 };
 
-class SPIClass : public IOMaster {
-  public:
+class SPIClass : public IOMaster
+{
+public:
   SPIClass(uint8_t iom_instance);
   SPIClass(uint8_t iom_instance, ap3_spi_duplex_e duplex);
 
@@ -122,7 +129,7 @@ class SPIClass : public IOMaster {
 
 private:
   void config(SPISettings settings);
-  void _transfer(void* buf_out = NULL, void* buf_in = NULL, size_t count = 0);
+  void _transfer(void *buf_out = NULL, void *buf_in = NULL, size_t count = 0);
 
   // Bit Order (need a better way to handle this)
   BitOrder _order;
@@ -131,9 +138,9 @@ private:
   ap3_spi_duplex_e _duplex;
 
   // Pads (for reference)
-  ap3_gpio_pin_t  _padSCLK;
-  ap3_gpio_pin_t  _padMOSI;
-  ap3_gpio_pin_t  _padMISO;
+  ap3_gpio_pin_t _padSCLK;
+  ap3_gpio_pin_t _padMOSI;
+  ap3_gpio_pin_t _padMISO;
 
   // SERCOM *_p_sercom;
   // uint8_t _uc_pinMiso;
@@ -150,34 +157,34 @@ private:
 };
 
 #if SPI_INTERFACES_COUNT > 0
-  extern SPIClass SPI;
+extern SPIClass SPI;
 #endif
 #if SPI_INTERFACES_COUNT > 1
-  extern SPIClass SPI1;
+extern SPIClass SPI1;
 #endif
 #if SPI_INTERFACES_COUNT > 2
-  extern SPIClass SPI2;
+extern SPIClass SPI2;
 #endif
 #if SPI_INTERFACES_COUNT > 3
-  extern SPIClass SPI3;
+extern SPIClass SPI3;
 #endif
 #if SPI_INTERFACES_COUNT > 4
-  extern SPIClass SPI4;
+extern SPIClass SPI4;
 #endif
 #if SPI_INTERFACES_COUNT > 5
-  extern SPIClass SPI5;
+extern SPIClass SPI5;
 #endif
 
 // For compatibility with sketches designed for AVR @ 16 MHz
 // New programs should use SPI.beginTransaction to set the SPI clock
 #if F_CPU == 48000000
-  #define SPI_CLOCK_DIV2   6
-  #define SPI_CLOCK_DIV4   12
-  #define SPI_CLOCK_DIV8   24
-  #define SPI_CLOCK_DIV16  48
-  #define SPI_CLOCK_DIV32  96
-  #define SPI_CLOCK_DIV64  192
-  #define SPI_CLOCK_DIV128 255
+#define SPI_CLOCK_DIV2 6
+#define SPI_CLOCK_DIV4 12
+#define SPI_CLOCK_DIV8 24
+#define SPI_CLOCK_DIV16 48
+#define SPI_CLOCK_DIV32 96
+#define SPI_CLOCK_DIV64 192
+#define SPI_CLOCK_DIV128 255
 #endif
 
 #endif


### PR DESCRIPTION
Added return value to _interruptStatus. I'm not entirely confident we are returning all we should.

Here is [example](https://github.com/Seeed-Studio/Arduino_IDE_for_RePhone/blob/master/hardware/arduino/sam/libraries/SPI/SPI.cpp) returning fault mask register as well.

[Here](https://git.ccmob.net/marcel/platformio-pkg-framework-arduinosam/commit/cf28026aef2f65e2ddc5c631d2b01a144ff0a068) is one of very few example sketches I could find that actually use the __interruptsStatus() call.

Also in this PR - Small changes to SPI.h. I decided to remove warnings to SS pin definition. I've never used a pin called 'SS' and use a GPIO for CS instead. Apollo3 doesn't have hardware support for SS so I think we can expunge it. Also, changed warning on 'CLK' to 'SCK'. I see SCK more often for SPI pins and this follows the pad map for Apollo3.