### PR TITLE
Resolve warning and compile errors with examples.

### DIFF
--- a/libraries/EEPROM/examples/Example2_AllFunctions/Example2_AllFunctions.ino
+++ b/libraries/EEPROM/examples/Example2_AllFunctions/Example2_AllFunctions.ino
@@ -16,6 +16,11 @@
 
 #include <EEPROM.h>
 
+// Give a default if the variant does not define one.
+#ifndef A0
+#define A0 0
+#endif
+
 void setup()
 {
   Serial.begin(9600);
@@ -39,7 +44,7 @@ void setup()
   Serial.println("8 bit tests");
   byte myValue1 = 200;
   byte myValue2 = 23;
-  randomLocation = random(0, FLASH_EEPROM_SIZE);
+  randomLocation = random(0, AP3_FLASH_EEPROM_SIZE);
 
   startTime = millis();
   EEPROM.write(randomLocation, myValue1); //(location, data)
@@ -61,7 +66,7 @@ void setup()
   //-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-
   uint16_t myValue3 = 3411;
   int16_t myValue4 = -366;
-  randomLocation = random(0, FLASH_EEPROM_SIZE);
+  randomLocation = random(0, AP3_FLASH_EEPROM_SIZE);
 
   EEPROM.put(randomLocation, myValue3);
   EEPROM.put(randomLocation + 2, myValue4);
@@ -82,7 +87,7 @@ void setup()
   Serial.printf("Size of int: %d\n", sizeof(int));
   int myValue5 = -245000;
   unsigned int myValue6 = 400123;
-  randomLocation = random(0, FLASH_EEPROM_SIZE);
+  randomLocation = random(0, AP3_FLASH_EEPROM_SIZE);
 
   EEPROM.put(randomLocation, myValue5);
   EEPROM.put(randomLocation + 4, myValue6);
@@ -99,7 +104,7 @@ void setup()
   //-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-
   int32_t myValue7 = -341002;
   uint32_t myValue8 = 241544;
-  randomLocation = random(0, FLASH_EEPROM_SIZE);
+  randomLocation = random(0, AP3_FLASH_EEPROM_SIZE);
 
   EEPROM.update(randomLocation, myValue7);
   EEPROM.update(randomLocation + 4, myValue8);
@@ -117,7 +122,7 @@ void setup()
   Serial.printf("Size of float: %d\n", sizeof(float));
   float myValue9 = -7.35;
   float myValue10 = 5.22;
-  randomLocation = random(0, FLASH_EEPROM_SIZE);
+  randomLocation = random(0, AP3_FLASH_EEPROM_SIZE);
 
   EEPROM.update(randomLocation, myValue9);
   EEPROM.update(randomLocation + 4, myValue10);
@@ -138,7 +143,7 @@ void setup()
   Serial.printf("Size of double: %d\n", sizeof(double));
   double myValue11 = -290.3485723409857;
   double myValue12 = 384.95734987;
-  randomLocation = random(0, FLASH_EEPROM_SIZE);
+  randomLocation = random(0, AP3_FLASH_EEPROM_SIZE);
 
   EEPROM.update(randomLocation, myValue11);
   EEPROM.update(randomLocation + 8, myValue12);
@@ -157,7 +162,7 @@ void setup()
   {
     if (x % 32 == 0)
       Serial.println();
-    Serial.printf("0x%08X ", *(uint32_t *)(FLASH_EEPROM_START + x));
+    Serial.printf("0x%08X ", *(uint32_t *)(AP3_FLASH_EEPROM_START + x));
   }
   Serial.println();
 }

--- a/libraries/EEPROM/src/EEPROM.cpp
+++ b/libraries/EEPROM/src/EEPROM.cpp
@@ -113,8 +113,8 @@ void ap3_EEPROM::get(uint16_t eepromLocation, double &dataToGet)
     double lf;
     uint32_t b[2];
   } temp;
-  temp.b[1] = *(uint32_t *)(AP3_FLASH_EEPROM_START + eepromLocation);           //LSB;
-  temp.b[0] = *(uint32_t *)(AP3_FLASH_EEPROM_START + eepromLocation + 4) << 32; //MSB;
+  temp.b[1] = *(uint32_t *)(AP3_FLASH_EEPROM_START + eepromLocation);     //LSB;
+  temp.b[0] = *(uint32_t *)(AP3_FLASH_EEPROM_START + eepromLocation + 4); //MSB;
   dataToGet = temp.lf;
 }
 

--- a/libraries/SPI/src/SPI.h
+++ b/libraries/SPI/src/SPI.h
@@ -23,17 +23,6 @@
 #include <Arduino.h>
 #include "ap3_iomaster.h"
 
-// Give a warning if the variant did not define these symbols:
-#ifndef MOSI
-#warning "variant has no definition for pin number 'MOSI'"
-#endif // MOSI
-#ifndef MISO
-#warning "variant has no definition for pin number 'MISO'"
-#endif // MISO
-#ifndef SCK
-#warning "variant has no definition for pin number 'SCK'"
-#endif // SCK
-
 // SPI_HAS_TRANSACTION means SPI has
 //   - beginTransaction()
 //   - endTransaction()


### PR DESCRIPTION
Resolves all warning and compile errors on all examples on all boards except those listed below.  Tested with test harness at: https://github.com/konkers/Arduino_Apollo3/commit/efdb5489437e18e90c24f1e9c3e11e1e5bf416ea

### Tests skipped
libraries/Examples/examples/Example2_Serial:
 * SparkFun:apollo3:artemis
 * SparkFun:apollo3:edge2
 * SparkFun:apollo3:edge

libraries/PDM/examples/Example1_MicrophoneOutput:
 * SparkFun:apollo3:edge


libraries/PDM/examples/Example2_ConfigureMic:
 * SparkFun:apollo3:edge

libraries/PDM/examples/Example3_FullConfigure:
 * SparkFun:apollo3:edge

libraries/Servo/examples/Example6_19servos:
 * SparkFun:apollo3:amap3atp
 * SparkFun:apollo3:amap3nano
 * SparkFun:apollo3:artemis
 * SparkFun:apollo3:edge2
 * SparkFun:apollo3:edge

libraries/Servo/examples/Example7_29servos:
 * SparkFun:apollo3:amap3nano
 * SparkFun:apollo3:artemis
 * SparkFun:apollo3:edge2
 * SparkFun:apollo3:edge
 * SparkFun:apollo3:edge2
