### PR TITLE
Change SoftwareSerial to inherit from Stream

### DIFF
--- a/libraries/SoftwareSerial/src/SoftwareSerial.h
+++ b/libraries/SoftwareSerial/src/SoftwareSerial.h
@@ -38,12 +38,13 @@
 #ifndef _SoftwareSerial_H
 #define _SoftwareSerial_H
 #include "Arduino.h"
+#include <Stream.h>
 
 #define AP3_SS_BUFFER_SIZE 128 //Limit to 8 bits
 
 #define TIMER_FREQ 3000000L
 
-class SoftwareSerial : public Print
+class SoftwareSerial : public Stream
 {
 public:
   SoftwareSerial(uint8_t rxPin, uint8_t txPin, bool invertLogic = false);


### PR DESCRIPTION
Change SS to inherit from Stream instead of Print. There are some libraries that expect softwareSerial to have functions like find() and setTimeout(). This fixes those 'function not found' errors.