### PR TITLE
Add highlighting to RTC functions

### DIFF
--- a/libraries/RTC/keywords.txt
+++ b/libraries/RTC/keywords.txt
@@ -16,6 +16,17 @@ getTime	KEYWORD2
 setTime	KEYWORD2
 setTimeToCompiler	KEYWORD2
 
+hour	KEYWORD2
+minute	KEYWORD2
+seconds	KEYWORD2
+hundredths	KEYWORD2
+
+month	KEYWORD2
+dayOfMonth	KEYWORD2
+year	KEYWORD2
+weekday	KEYWORD2
+textWeekday	KEYWORD2
+
 #######################################
 # Constants (LITERAL1)
 #######################################


### PR DESCRIPTION
Simple add. Just adds a few highlighted words. I should have had these in the original contribution.