### PR TITLE
Increase pullup resistor on RX pin

### DIFF
--- a/libraries/SoftwareSerial/src/SoftwareSerial.cpp
+++ b/libraries/SoftwareSerial/src/SoftwareSerial.cpp
@@ -122,7 +122,13 @@ void SoftwareSerial::begin(uint32_t baudRate, HardwareSerial_Config_e SSconfig)
 
   pinMode(_rxPin, INPUT);
   if (_invertLogic == false)
-    pinMode(_rxPin, INPUT_PULLUP); //Enable external pullup if using normal logic
+  {
+    //Enable external pullup if using normal logic
+    //On some GPIO the g_AM_HAL_GPIO_INPUT_PULLUP seems to be strong enough
+    //to cause problems translation buffers like the TXB0104. Limiting
+    //to 24k fixing issue.
+    pinMode(_rxPin, g_AM_HAL_GPIO_INPUT_PULLUP_24);
+  }
 
 #ifdef DEBUG
   am_hal_gpio_output_clear(debugPad);


### PR DESCRIPTION
This PR makes software serial work reliably on pins connected to translation buffers such as the TXB0104 used on the SparkFun LTE cellular shield.

On some GPIO the g_AM_HAL_GPIO_INPUT_PULLUP seems to be strong enough to cause problems with translation buffers like the TXB0104. Limiting to the pullup to 24k fixes the issue.

With just g_AM_HAL_GPIO_INPUT_PULLUP the TXB0104 has a min voltage of 1.28V:

![image](https://user-images.githubusercontent.com/117102/67523987-065ae880-f66d-11e9-9adf-fb5cdf76d745.png)

The Apollo3 can't interpret the 1.3V as low .

But if we use the 24k pullup g_AM_HAL_GPIO_INPUT_PULLUP_24 the signal gets much better:

![image](https://user-images.githubusercontent.com/117102/67524090-491cc080-f66d-11e9-9f78-213f8c639f76.png)

And just for fun, here is pull up with 12k. The low voltage raises as the pull up resistance decreases we would expect:

![image](https://user-images.githubusercontent.com/117102/67524161-6d789d00-f66d-11e9-8d39-b9594d030e31.png)

This suggests the generic "g_AM_HAL_GPIO_INPUT_PULLUP" uses a strong pullup, however it's not clear in the HAL what "WEAK" means:

![image](https://user-images.githubusercontent.com/117102/67524284-ae70b180-f66d-11e9-89f7-d91c501f6a6c.png)

I don't believe there is a downside to using the 22k pull up value rather than the 'WEAK' value.