### PR TITLE
Clear PCI at end of byte

### DIFF
--- a/libraries/SoftwareSerial/src/SoftwareSerial.cpp
+++ b/libraries/SoftwareSerial/src/SoftwareSerial.cpp
@@ -594,6 +594,8 @@ void SoftwareSerial::rxEndOfByte()
 
   rxInUse = false; //Release so that we can TX if needed
 
+  am_hal_gpio_interrupt_clear(AM_HAL_GPIO_BIT(_rxPad)); //Clear any residual PCIs
+
   // Disable the timer interrupt in the NVIC.
   NVIC_DisableIRQ(STIMER_CMPR7_IRQn);
 }


### PR DESCRIPTION
This PR fixes a bug that corrupts non-visible ASCII.

Notes:

The Pin Change Interrupt was firing after the compare interrupt (completion of byte) which was causing the incorrect start of a new byte. PCI is now cleared at the end of Compare. In the future, we could change the PCI from CHANGE to FALLING to be more sure that we're seeing the start of a new byte but it's not a guarantee. And this PR works.

This was found while connecting the Artemis to the LTE shield using software serial. Lots of \n and \r's in the AT command flows that were getting corrupt. This fixes those corruptions.

 