### PR TITLE
Tensorflow micro lite compatibility

### DIFF
--- a/cores/arduino/ard_sup/Arduino_defines.h
+++ b/cores/arduino/ard_sup/Arduino_defines.h
@@ -28,8 +28,8 @@
 #undef abs
 #endif // abs
 
-// #define min(a, b) ((a) < (b) ? (a) : (b))
-// #define max(a, b) ((a) > (b) ? (a) : (b))
+#define min(a, b) ((a) < (b) ? (a) : (b))
+#define max(a, b) ((a) > (b) ? (a) : (b))
 #define abs(x) ((x) > 0 ? (x) : -(x))
 #define constrain(amt, low, high) ((amt) < (low) ? (low) : ((amt) > (high) ? (high) : (amt)))
 #define round(x) ((x) >= 0 ? (long)((x) + 0.5) : (long)((x)-0.5))

--- a/cores/arduino/ard_sup/Arduino_defines.h
+++ b/cores/arduino/ard_sup/Arduino_defines.h
@@ -28,8 +28,8 @@
 #undef abs
 #endif // abs
 
-#define min(a, b) ((a) < (b) ? (a) : (b))
-#define max(a, b) ((a) > (b) ? (a) : (b))
+// #define min(a, b) ((a) < (b) ? (a) : (b))
+// #define max(a, b) ((a) > (b) ? (a) : (b))
 #define abs(x) ((x) > 0 ? (x) : -(x))
 #define constrain(amt, low, high) ((amt) < (low) ? (low) : ((amt) > (high) ? (high) : (amt)))
 #define round(x) ((x) >= 0 ? (long)((x) + 0.5) : (long)((x)-0.5))

--- a/cores/arduino/ard_sup/analog/ap3_analog.cpp
+++ b/cores/arduino/ard_sup/analog/ap3_analog.cpp
@@ -125,6 +125,12 @@ uint8_t _servoWriteBits = 8;  // 8-bit by default for writes
 
 uint16_t analogRead(uint8_t pinNumber)
 {
+    static bool ap3_adc_initialized = false;
+    if(!ap3_adc_initialized){
+        ap3_adc_setup();
+        ap3_adc_initialized = true;
+    }
+
     uint32_t ui32IntMask;
     am_hal_adc_sample_t Sample;
     uint32_t ui32NumSamples = 1;

--- a/cores/arduino/ard_sup/main.cpp
+++ b/cores/arduino/ard_sup/main.cpp
@@ -21,7 +21,7 @@ extern "C" int main(void)
 
   ap3_variant_init();
 
-  ap3_adc_setup();
+  // ap3_adc_setup();
 
   setup();
   for (;;)


### PR DESCRIPTION
@nseidle these are some changes that I had to make when getting the TFLM code to run on Edge. My concern is about the 2nd commit. Maybe one solution would be to implement a template function that could be used wherever the original macro would have been used. That way the signatures can be different (conflict is with ```min``` as used here):

```stl_algobase.h```
``` c++
  template<typename _Tp, typename _Compare>
    _GLIBCXX14_CONSTEXPR
    inline const _Tp&
    min(const _Tp& __a, const _Tp& __b, _Compare __comp)
    {
      //return __comp(__b, __a) ? __b : __a;
      if (__comp(__b, __a))
	return __b;
      return __a;
    }
```