### PR TITLE
Increase baseline SPI bulk transfer speeds

### DIFF
--- a/libraries/SPI/src/SPI.cpp
+++ b/libraries/SPI/src/SPI.cpp
@@ -122,6 +122,10 @@ void SPIClass::config(SPISettings settings)
 {
   memset((void *)&_config, 0x00, sizeof(am_hal_iom_config_t)); // Set the IOM configuration
   _config.eInterfaceMode = AM_HAL_IOM_SPI_MODE;
+
+  if (settings.clockFreq > AM_HAL_IOM_MAX_FREQ)
+    settings.clockFreq = AM_HAL_IOM_MAX_FREQ;
+
   _config.ui32ClockFreq = settings.clockFreq;
   _config.eSpiMode = settings.dataMode;
   _order = settings.bitOrder;

--- a/libraries/SPI/src/SPI.cpp
+++ b/libraries/SPI/src/SPI.cpp
@@ -28,6 +28,8 @@
 
 const SPISettings DEFAULT_SPI_SETTINGS = SPISettings();
 
+am_hal_iom_transfer_t iomTransfer = {0};
+
 SPIClass::SPIClass(uint8_t iom_instance) : IOMaster(iom_instance)
 {
   _duplex = ap3_spi_full_duplex;
@@ -105,6 +107,15 @@ void SPIClass::begin()
   }
 
   config(DEFAULT_SPI_SETTINGS);
+
+  //Set global's settings that won't change between transfers
+  iomTransfer.ui32InstrLen = 0; // No instructions
+  iomTransfer.ui32Instr = 0;    // No instructions
+  iomTransfer.bContinue = false;
+  iomTransfer.ui8RepeatCount = 0;     // ?
+  iomTransfer.ui8Priority = 1;        // ?
+  iomTransfer.ui32PauseCondition = 0; // ?
+  iomTransfer.ui32StatusSetClr = 0;   // ?
 }
 
 void SPIClass::config(SPISettings settings)
@@ -272,19 +283,9 @@ void SPIClass::transferIn(void *buf, size_t count)
 
 void SPIClass::_transfer(void *buf_out, void *buf_in, size_t count)
 {
-  am_hal_iom_transfer_t iomTransfer = {0};
-  // iomTransfer.uPeerInfo.ui32SpiChipSelect = cs_pad;
-  iomTransfer.ui32InstrLen = 0;     // No instructions
-  iomTransfer.ui32Instr = 0;        // No instructions
-  iomTransfer.ui32NumBytes = count; // How many bytes to transfer
-  // iomTransfer.eDirection = AM_HAL_IOM_TX; // AM_HAL_IOM_FULLDUPLEX - Note: Ambiq SDK says that FULLDUPLEX is not yet supported // todo:
+  iomTransfer.ui32NumBytes = count;                // How many bytes to transfer
   iomTransfer.pui32TxBuffer = (uint32_t *)buf_out; // todo: does this have the proper lifetime?
   iomTransfer.pui32RxBuffer = (uint32_t *)buf_in;
-  iomTransfer.bContinue = false;
-  iomTransfer.ui8RepeatCount = 0;     // ?
-  iomTransfer.ui8Priority = 1;        // ?
-  iomTransfer.ui32PauseCondition = 0; // ?
-  iomTransfer.ui32StatusSetClr = 0;   // ?
 
   // Determine direction
   if ((buf_out != NULL) && (buf_in != NULL))


### PR DESCRIPTION
This decreases the byte wise transaction from 26us to 19us, a 25% improvement. It does it by moving the iomTransfer struct to global and assigning the values that don't change into the begin function.

These changes along with the SDfat changes (incoming) make for some spectacular performance:

With SPI clock freq at 48MHz we get 

write: 286 / 289 kb/s
read: 958 / 958 kb/s

On a clean format, 8GB Sandisk microSD card.

There was also a bug that allowed the core SPI freq to go above 48MHz. This PR fixes that as well.