### PR TITLE
Fix for Broken Arduino libraries due to implementaion of commonly used GPIO constants, issue #98

### DIFF
--- a/cores/arduino/ard_sup/analog/ap3_analog.cpp
+++ b/cores/arduino/ard_sup/analog/ap3_analog.cpp
@@ -313,7 +313,7 @@ ap3_err_t ap3_set_pin_to_analog(uint8_t pinNumber)
     ap3_err_t retval = AP3_ERR;
 
     uint8_t funcsel = 0;
-    am_hal_gpio_pincfg_t pincfg = INPUT;
+    am_hal_gpio_pincfg_t pincfg = AP3_PINCFG_INPUT;
     retval = ap3_analog_pad_funcsel(ap3_gpio_pin2pad(pinNumber), &funcsel);
 
     if (retval != AP3_OK)

--- a/cores/arduino/ard_sup/ap3_gpio.h
+++ b/cores/arduino/ard_sup/ap3_gpio.h
@@ -34,12 +34,21 @@ extern const am_hal_gpio_pincfg_t g_AM_HAL_GPIO_OUTPUT_WITH_READ_12;
 extern const am_hal_gpio_pincfg_t g_AM_HAL_GPIO_OPEN_DRAIN_WITH_READ_12;
 extern const am_hal_gpio_pincfg_t g_AM_HAL_GPIO_INPUT_PULLDOWN;
 
-#define INPUT (g_AM_HAL_GPIO_INPUT)
-#define OUTPUT (g_AM_HAL_GPIO_OUTPUT_WITH_READ_12)
-#define OPEN_DRAIN (g_AM_HAL_GPIO_OPEN_DRAIN_WITH_READ_12)
-#define TRISTATE (g_AM_HAL_GPIO_TRISTATE)
-#define INPUT_PULLUP (g_AM_HAL_GPIO_INPUT_PULLUP)
-#define INPUT_PULLDOWN (g_AM_HAL_GPIO_INPUT_PULLDOWN)
+// macros pointing to internal apollo3 GPIO pincfg structures
+#define AP3_PINCFG_INPUT            (g_AM_HAL_GPIO_INPUT)
+#define AP3_PINCFG_OUTPUT           (g_AM_HAL_GPIO_OUTPUT_WITH_READ_12)
+#define AP3_PINCFG_INPUT_PULLUP     (g_AM_HAL_GPIO_INPUT_PULLUP)
+#define AP3_PINCFG_INPUT_PULLDOWN   (g_AM_HAL_GPIO_INPUT_PULLDOWN)
+#define AP3_PINCFG_OPEN_DRAIN       (g_AM_HAL_GPIO_OPEN_DRAIN_WITH_READ_12)
+#define AP3_PINCFG_TRISTATE         (g_AM_HAL_GPIO_TRISTATE)
+
+// constants for Arduino pin modes
+#define INPUT           (0x00)
+#define OUTPUT          (0x01)
+#define INPUT_PULLUP    (0x02)
+#define INPUT_PULLDOWN  (0x03)
+#define OPEN_DRAIN      (0x04)
+#define TRISTATE        (0x05)
 
 #define AP3_GPIO_MAX_PADS (50)
 #define AP3_GPIO_IS_VALID(pad) ((pad >= 0) && (pad < AP3_GPIO_MAX_PADS))
@@ -59,6 +68,7 @@ uint32_t ap3_gpio_enable_interrupts(uint32_t ui32Pin, uint32_t eIntDir);
 void padMode(uint8_t pad, am_hal_gpio_pincfg_t mode);
 void padMode(uint8_t pad, am_hal_gpio_pincfg_t mode, ap3_err_t *retval);
 
+void pinMode(uint8_t pin, uint8_t mode);
 void pinMode(uint8_t pin, am_hal_gpio_pincfg_t mode);
 void pinMode(uint8_t pin, am_hal_gpio_pincfg_t mode, ap3_err_t *retval);
 void digitalWrite(uint8_t pin, uint8_t val);

--- a/cores/arduino/ard_sup/gpio/ap3_gpio.cpp
+++ b/cores/arduino/ard_sup/gpio/ap3_gpio.cpp
@@ -75,6 +75,38 @@ void padMode(uint8_t pad, am_hal_gpio_pincfg_t mode)
     padMode(pad, mode, NULL);
 }
 
+// translate Arduino style pin mode function to apollo3 implementation
+void pinMode(uint8_t pin, uint8_t mode) {
+
+    am_hal_gpio_pincfg_t pinmode = AP3_GPIO_PINCFG_NULL;
+
+    switch (mode) {
+        case INPUT:
+            pinmode = AP3_PINCFG_INPUT;
+            break;
+        case OUTPUT:
+            pinmode = AP3_PINCFG_OUTPUT;
+            break;
+        case INPUT_PULLUP:
+            pinmode = AP3_PINCFG_INPUT_PULLUP;
+            break;
+        case INPUT_PULLDOWN:
+            pinmode = AP3_PINCFG_INPUT_PULLDOWN;
+            break;
+        case OPEN_DRAIN:
+            pinmode = AP3_PINCFG_OPEN_DRAIN;
+            break;
+        case TRISTATE:
+            pinmode = AP3_PINCFG_TRISTATE;
+            break;
+        default:
+            //no match, just do nothing
+            return;
+    }
+
+    pinMode(pin, pinmode);
+}
+
 void pinMode(uint8_t pin, am_hal_gpio_pincfg_t mode, ap3_err_t *retval)
 {
     ap3_gpio_pad_t pad = ap3_gpio_pin2pad(pin);

--- a/docs/ACKNOWLEDGEMENTS.md
+++ b/docs/ACKNOWLEDGEMENTS.md
@@ -11,4 +11,5 @@ Contributors
 * Jim Lindblom
 * Kenny Hora
 * Owen Lyke
+* Aaron Micyus
 * Nathan Seidle


### PR DESCRIPTION
For your review, a potential fix for issue #98.
The changes add a new pinMode function that maps commonly used Arduino pin mode constants to internal methods using a pincfg structure and makes changes to existing defines to reflect this update.

Please Note:
1) In the implementation of the pinMode function I used a variable to assign the desired pin mode mapping and just called the internal function once. I did this instead of calling the function at each case (without the variable) because it seemed like it looked cleaner and may optimize better.  However this assumes the am_hal_gpio_pincfg_t structure is safe to assign to a new variable (does not use pointers, etc).  In this case the implementation is safe but future modifications could potentially break this if the = operator is not overloaded to account for it.
I could easily change it back to an alternate implementation that would be safer long term if you all are ok with the extra instances of functions calls in the generated code.  I saw other instances in the code where assignment was being made between am_hal_gpio_pincfg_t variables so I assumed this was already factored into consideration.

2) In the implementation of the pinMode function when there is an invalid value passed in for the pin mode I just return and do nothing.  There did not seem to be an error checking semantics in place for the original pinMode functions so it seemed safest just to do nothing.

3) I was trying to hold back my OCD and was pretty sparse in my comments using the existing level of detail as a guide.  If a different level of detail is desired just let me know.