### PR TITLE
Allow for changing pull ups for Wire pins

### DIFF
--- a/libraries/Wire/keywords.txt
+++ b/libraries/Wire/keywords.txt
@@ -17,6 +17,8 @@ requestFrom	KEYWORD2
 onReceive	KEYWORD2
 onRequest	KEYWORD2
 setClock	KEYWORD2
+setPullups	KEYWORD2
+
 
 #######################################
 # Instances (KEYWORD2)

--- a/libraries/Wire/src/Wire.cpp
+++ b/libraries/Wire/src/Wire.cpp
@@ -92,6 +92,18 @@ void TwoWire::begin(void)
 	_config.eInterfaceMode = AM_HAL_IOM_I2C_MODE;
 	_config.ui32ClockFreq = _clockSpeed;
 
+	//Setup defaults that do not change
+	iomTransfer.ui32InstrLen = 0; // Use only data phase
+	iomTransfer.ui32Instr = 0;	//
+	// iomTransfer.ui32NumBytes = ;         //
+	iomTransfer.eDirection = AM_HAL_IOM_TX;
+	iomTransfer.pui32TxBuffer = (uint32_t *)_linearBugger;
+	iomTransfer.pui32RxBuffer = NULL;
+	iomTransfer.ui8RepeatCount = 0;		// ?
+	iomTransfer.ui8Priority = 1;		// ?
+	iomTransfer.ui32PauseCondition = 0; // ?
+	iomTransfer.ui32StatusSetClr = 0;   // ?
+
 	initialize(); // Initialize the IOM
 }
 
@@ -190,19 +202,8 @@ uint8_t TwoWire::endTransmission(bool stopBit)
 {
 	_transmissionBegun = false;
 
-	am_hal_iom_transfer_t iomTransfer = {0};
 	iomTransfer.uPeerInfo.ui32I2CDevAddr = _transmissionAddress;
-	iomTransfer.ui32InstrLen = 0; // Use only data phase
-	iomTransfer.ui32Instr = 0;	//
-	// iomTransfer.ui32NumBytes = ;         //
-	iomTransfer.eDirection = AM_HAL_IOM_TX;
-	iomTransfer.pui32TxBuffer = (uint32_t *)_linearBugger;
-	iomTransfer.pui32RxBuffer = NULL;
 	iomTransfer.bContinue = (stopBit ? false : true); // whether or not to hold onto the bus after this transfer
-	iomTransfer.ui8RepeatCount = 0;					  // ?
-	iomTransfer.ui8Priority = 1;					  // ?
-	iomTransfer.ui32PauseCondition = 0;				  // ?
-	iomTransfer.ui32StatusSetClr = 0;				  // ?
 
 	// Copy the bytes from the TX Buffer into the linear buffer
 	size_t count = 0;

--- a/libraries/Wire/src/Wire.cpp
+++ b/libraries/Wire/src/Wire.cpp
@@ -114,11 +114,11 @@ void TwoWire::setPullups(uint32_t pullupAmount)
 {
 	if (pullupAmount == 0)
 		_pullups = AM_HAL_GPIO_PIN_PULLUP_NONE;
-	if (pullupAmount > 0 || pullupAmount < 6)
+	if (pullupAmount > 0 && pullupAmount < 6)
 		_pullups = AM_HAL_GPIO_PIN_PULLUP_1_5K;
-	else if (pullupAmount >= 6 || pullupAmount < 12)
+	else if (pullupAmount >= 6 && pullupAmount < 12)
 		_pullups = AM_HAL_GPIO_PIN_PULLUP_6K;
-	else if (pullupAmount >= 12 || pullupAmount < 24)
+	else if (pullupAmount >= 12 && pullupAmount < 24)
 		_pullups = AM_HAL_GPIO_PIN_PULLUP_12K;
 	else if (pullupAmount >= 24)
 		_pullups = AM_HAL_GPIO_PIN_PULLUP_24K;

--- a/libraries/Wire/src/Wire.h
+++ b/libraries/Wire/src/Wire.h
@@ -30,77 +30,77 @@ SOFTWARE.
 
 #define AP3_WIRE_RX_BUFFER_LEN 256
 #define AP3_WIRE_TX_BUFFER_LEN 256
-#define AP3_WIRE_LINEAR_BUFFER_LEN (AP3_WIRE_RX_BUFFER_LEN+AP3_WIRE_TX_BUFFER_LEN)
+#define AP3_WIRE_LINEAR_BUFFER_LEN (AP3_WIRE_RX_BUFFER_LEN + AP3_WIRE_TX_BUFFER_LEN)
 
- // WIRE_HAS_END means Wire has end()
+// WIRE_HAS_END means Wire has end()
 #define WIRE_HAS_END 1
 
-class TwoWire : public Stream, public IOMaster {
-  public:
-    TwoWire(uint8_t iom_instance);
-    void begin();
-    void begin(uint8_t, bool enableGeneralCall = false);
-    void end();
-    void setClock(uint32_t);
+class TwoWire : public Stream, public IOMaster
+{
+public:
+  TwoWire(uint8_t iom_instance);
+  void begin();
+  void begin(uint8_t, bool enableGeneralCall = false);
+  void end();
+  void setClock(uint32_t);
 
-    void beginTransmission(uint8_t address);
-    uint8_t endTransmission(bool stopBit = true);
+  void beginTransmission(uint8_t address);
+  uint8_t endTransmission(bool stopBit = true);
 
-    uint8_t requestFrom(uint8_t address, size_t quantity, bool stopBit = true);
+  uint8_t requestFrom(uint8_t address, size_t quantity, bool stopBit = true);
 
-    size_t write(uint8_t data);
-    size_t write(const uint8_t * data, size_t quantity);
+  size_t write(uint8_t data);
+  size_t write(const uint8_t *data, size_t quantity);
 
-    virtual int available(void);
-    virtual int read(void);
-    virtual int peek(void);
-    virtual void flush(void);
-    void onReceive(void(*)(int));
-    void onRequest(void(*)(void));
+  virtual int available(void);
+  virtual int read(void);
+  virtual int peek(void);
+  virtual void flush(void);
+  void onReceive(void (*)(int));
+  void onRequest(void (*)(void));
 
-    inline size_t write(unsigned long n) { return write((uint8_t)n); }
-    inline size_t write(long n) { return write((uint8_t)n); }
-    inline size_t write(unsigned int n) { return write((uint8_t)n); }
-    inline size_t write(int n) { return write((uint8_t)n); }
-    using Print::write;
+  inline size_t write(unsigned long n) { return write((uint8_t)n); }
+  inline size_t write(long n) { return write((uint8_t)n); }
+  inline size_t write(unsigned int n) { return write((uint8_t)n); }
+  inline size_t write(int n) { return write((uint8_t)n); }
+  using Print::write;
 
-    void onService(void);
+  void onService(void);
 
-  private:
-    ap3_gpio_pin_t  _padSDA;
-    ap3_gpio_pin_t  _padSCL;
+private:
+  ap3_gpio_pin_t _padSDA;
+  ap3_gpio_pin_t _padSCL;
 
-    bool _transmissionBegun;
-    uint8_t _transmissionAddress;
+  bool _transmissionBegun;
+  uint8_t _transmissionAddress;
 
-    
-    RingBufferN<AP3_WIRE_RX_BUFFER_LEN> _rxBuffer;// RX Buffer    
-    RingBufferN<AP3_WIRE_TX_BUFFER_LEN> _txBuffer;// TX buffer
-    uint8_t _linearBugger[AP3_WIRE_LINEAR_BUFFER_LEN]; // ToDo: choose a more efficient way to handle this
-    uint8_t txAddress;
+  RingBufferN<AP3_WIRE_RX_BUFFER_LEN> _rxBuffer;     // RX Buffer
+  RingBufferN<AP3_WIRE_TX_BUFFER_LEN> _txBuffer;     // TX buffer
+  uint8_t _linearBugger[AP3_WIRE_LINEAR_BUFFER_LEN]; // ToDo: choose a more efficient way to handle this
+  uint8_t txAddress;
 
-    // Callback user functions
-    void (*_onRequestCallback)(void);
-    void (*_onReceiveCallback)(int);
+  // Callback user functions
+  void (*_onRequestCallback)(void);
+  void (*_onReceiveCallback)(int);
 };
 
 #if WIRE_INTERFACES_COUNT > 0
-  extern TwoWire Wire;
+extern TwoWire Wire;
 #endif
 #if WIRE_INTERFACES_COUNT > 1
-  extern TwoWire Wire1;
+extern TwoWire Wire1;
 #endif
 #if WIRE_INTERFACES_COUNT > 2
-  extern TwoWire Wire2;
+extern TwoWire Wire2;
 #endif
 #if WIRE_INTERFACES_COUNT > 3
-  extern TwoWire Wire3;
+extern TwoWire Wire3;
 #endif
 #if WIRE_INTERFACES_COUNT > 4
-  extern TwoWire Wire4;
+extern TwoWire Wire4;
 #endif
 #if WIRE_INTERFACES_COUNT > 5
-  extern TwoWire Wire5;
+extern TwoWire Wire5;
 #endif
 
 #endif // _AP3_WIRE_H_

--- a/libraries/Wire/src/Wire.h
+++ b/libraries/Wire/src/Wire.h
@@ -69,6 +69,7 @@ public:
   void onService(void);
 
 private:
+  am_hal_iom_transfer_t iomTransfer = {0};
   ap3_gpio_pin_t _padSDA;
   ap3_gpio_pin_t _padSCL;
 

--- a/libraries/Wire/src/Wire.h
+++ b/libraries/Wire/src/Wire.h
@@ -43,6 +43,7 @@ public:
   void begin(uint8_t, bool enableGeneralCall = false);
   void end();
   void setClock(uint32_t);
+  void setPullups(uint32_t);
 
   void beginTransmission(uint8_t address);
   uint8_t endTransmission(bool stopBit = true);
@@ -73,6 +74,8 @@ private:
 
   bool _transmissionBegun;
   uint8_t _transmissionAddress;
+  uint32_t _pullups;
+  uint32_t _clockSpeed;
 
   RingBufferN<AP3_WIRE_RX_BUFFER_LEN> _rxBuffer;     // RX Buffer
   RingBufferN<AP3_WIRE_TX_BUFFER_LEN> _txBuffer;     // TX buffer

--- a/libraries/Wire/src/Wire.h
+++ b/libraries/Wire/src/Wire.h
@@ -74,7 +74,7 @@ private:
 
   bool _transmissionBegun;
   uint8_t _transmissionAddress;
-  uint32_t _pullups;
+  am_hal_gpio_pullup_e _pullups;
   uint32_t _clockSpeed;
 
   RingBufferN<AP3_WIRE_RX_BUFFER_LEN> _rxBuffer;     // RX Buffer


### PR DESCRIPTION
I've added a setPullups() function. This allows users to select between 0, 1.5k, 6k, 12k, and 24k, for the built in pull ups on the I2C lines. Because we call begin() after user selects their pull up values, I needed to store clock speed. 

I addition, I moved the iomTransfer setup of default values to the begin function. This was done for SPI as well to decrease the amount of cycles spent setting up values for every I2C transfer. It won't save as much time as the SPI change did, but it will cut it down a bit. It does increase RAM footprint by the size of iomtransfer but I'm not worried about it.

I chose to allow user to pass a uint32_t to the **setPullups()** function. If desired, we could pass the full HAL type def of am_hal_gpio_pullup_e but I think it's easier to use a bare number. 

