### PR TITLE
Fix math.h

### DIFF
--- a/cores/arduino/am_sdk_ap3/CMSIS/ARM/Include/arm_math.h
+++ b/cores/arduino/am_sdk_ap3/CMSIS/ARM/Include/arm_math.h
@@ -162,7 +162,6 @@
    * Copyright (C) 2010-2015 Arm Limited. All rights reserved.
    */
 
-
 /**
  * @defgroup groupMath Basic Math Functions
  */
@@ -290,107 +289,105 @@
 #define _ARM_MATH_H
 
 /* Compiler specific diagnostic adjustment */
-#if   defined ( __CC_ARM )
+#if defined(__CC_ARM)
 
-#elif defined ( __ARMCC_VERSION ) && ( __ARMCC_VERSION >= 6010050 )
+#elif defined(__ARMCC_VERSION) && (__ARMCC_VERSION >= 6010050)
 
-#elif defined ( __GNUC__ )
+#elif defined(__GNUC__)
 #pragma GCC diagnostic push
 #pragma GCC diagnostic ignored "-Wsign-conversion"
 #pragma GCC diagnostic ignored "-Wconversion"
 #pragma GCC diagnostic ignored "-Wunused-parameter"
 
-#elif defined ( __ICCARM__ )
+#elif defined(__ICCARM__)
 
-#elif defined ( __TI_ARM__ )
+#elif defined(__TI_ARM__)
 
-#elif defined ( __CSMC__ )
+#elif defined(__CSMC__)
 
-#elif defined ( __TASKING__ )
+#elif defined(__TASKING__)
 
 #else
-  #error Unknown compiler
+#error Unknown compiler
 #endif
 
-
-#define __CMSIS_GENERIC         /* disable NVIC and Systick functions */
+#define __CMSIS_GENERIC /* disable NVIC and Systick functions */
 
 #if defined(ARM_MATH_CM7)
-  #include "core_cm7.h"
-  #define ARM_MATH_DSP
-#elif defined (ARM_MATH_CM4)
-  #include "core_cm4.h"
-  #define ARM_MATH_DSP
-#elif defined (ARM_MATH_CM3)
-  #include "core_cm3.h"
-#elif defined (ARM_MATH_CM0)
-  #include "core_cm0.h"
-  #define ARM_MATH_CM0_FAMILY
-#elif defined (ARM_MATH_CM0PLUS)
-  #include "core_cm0plus.h"
-  #define ARM_MATH_CM0_FAMILY
-#elif defined (ARM_MATH_ARMV8MBL)
-  #include "core_armv8mbl.h"
-  #define ARM_MATH_CM0_FAMILY
-#elif defined (ARM_MATH_ARMV8MML)
-  #include "core_armv8mml.h"
-  #if (defined (__DSP_PRESENT) && (__DSP_PRESENT == 1))
-    #define ARM_MATH_DSP
-  #endif
+#include "core_cm7.h"
+#define ARM_MATH_DSP
+#elif defined(ARM_MATH_CM4)
+#include "core_cm4.h"
+#define ARM_MATH_DSP
+#elif defined(ARM_MATH_CM3)
+#include "core_cm3.h"
+#elif defined(ARM_MATH_CM0)
+#include "core_cm0.h"
+#define ARM_MATH_CM0_FAMILY
+#elif defined(ARM_MATH_CM0PLUS)
+#include "core_cm0plus.h"
+#define ARM_MATH_CM0_FAMILY
+#elif defined(ARM_MATH_ARMV8MBL)
+#include "core_armv8mbl.h"
+#define ARM_MATH_CM0_FAMILY
+#elif defined(ARM_MATH_ARMV8MML)
+#include "core_armv8mml.h"
+#if (defined(__DSP_PRESENT) && (__DSP_PRESENT == 1))
+#define ARM_MATH_DSP
+#endif
 #else
-  #error "Define according the used Cortex core ARM_MATH_CM7, ARM_MATH_CM4, ARM_MATH_CM3, ARM_MATH_CM0PLUS, ARM_MATH_CM0, ARM_MATH_ARMV8MBL, ARM_MATH_ARMV8MML"
+#error "Define according the used Cortex core ARM_MATH_CM7, ARM_MATH_CM4, ARM_MATH_CM3, ARM_MATH_CM0PLUS, ARM_MATH_CM0, ARM_MATH_ARMV8MBL, ARM_MATH_ARMV8MML"
 #endif
 
-#undef  __CMSIS_GENERIC         /* enable NVIC and Systick functions */
+#undef __CMSIS_GENERIC /* enable NVIC and Systick functions */
 #include "string.h"
 #include "math.h"
-#ifdef   __cplusplus
+#ifdef __cplusplus
 extern "C"
 {
 #endif
-
 
   /**
    * @brief Macros required for reciprocal calculation in Normalized LMS
    */
 
-#define DELTA_Q31          (0x100)
-#define DELTA_Q15          0x5
-#define INDEX_MASK         0x0000003F
+#define DELTA_Q31 (0x100)
+#define DELTA_Q15 0x5
+#define INDEX_MASK 0x0000003F
 #ifndef PI
-  #define PI               3.14159265358979f
+#define PI 3.14159265358979f
 #endif
 
   /**
    * @brief Macros required for SINE and COSINE Fast math approximations
    */
 
-#define FAST_MATH_TABLE_SIZE  512
-#define FAST_MATH_Q31_SHIFT   (32 - 10)
-#define FAST_MATH_Q15_SHIFT   (16 - 10)
-#define CONTROLLER_Q31_SHIFT  (32 - 9)
-#define TABLE_SPACING_Q31     0x400000
-#define TABLE_SPACING_Q15     0x80
+#define FAST_MATH_TABLE_SIZE 512
+#define FAST_MATH_Q31_SHIFT (32 - 10)
+#define FAST_MATH_Q15_SHIFT (16 - 10)
+#define CONTROLLER_Q31_SHIFT (32 - 9)
+#define TABLE_SPACING_Q31 0x400000
+#define TABLE_SPACING_Q15 0x80
 
   /**
    * @brief Macros required for SINE and COSINE Controller functions
    */
   /* 1.31(q31) Fixed value of 2/360 */
   /* -1 to +1 is divided into 360 values so total spacing is (2/360) */
-#define INPUT_SPACING         0xB60B61
+#define INPUT_SPACING 0xB60B61
 
   /**
    * @brief Macro for Unaligned Support
    */
 #ifndef UNALIGNED_SUPPORT_DISABLE
-    #define ALIGN4
+#define ALIGN4
 #else
-  #if defined  (__GNUC__)
-    #define ALIGN4 __attribute__((aligned(4)))
-  #else
-    #define ALIGN4 __align(4)
-  #endif
-#endif   /* #ifndef UNALIGNED_SUPPORT_DISABLE */
+#if defined(__GNUC__)
+#define ALIGN4 __attribute__((aligned(4)))
+#else
+#define ALIGN4 __align(4)
+#endif
+#endif /* #ifndef UNALIGNED_SUPPORT_DISABLE */
 
   /**
    * @brief Error status returned by some functions in the library.
@@ -398,13 +395,13 @@ extern "C"
 
   typedef enum
   {
-    ARM_MATH_SUCCESS = 0,                /**< No error */
-    ARM_MATH_ARGUMENT_ERROR = -1,        /**< One or more arguments are incorrect */
-    ARM_MATH_LENGTH_ERROR = -2,          /**< Length of data buffer is incorrect */
-    ARM_MATH_SIZE_MISMATCH = -3,         /**< Size of matrices is not compatible with the operation. */
-    ARM_MATH_NANINF = -4,                /**< Not-a-number (NaN) or infinity is generated */
-    ARM_MATH_SINGULAR = -5,              /**< Generated by matrix inversion if the input matrix is singular and cannot be inverted. */
-    ARM_MATH_TEST_FAILURE = -6           /**< Test Failed  */
+    ARM_MATH_SUCCESS = 0,         /**< No error */
+    ARM_MATH_ARGUMENT_ERROR = -1, /**< One or more arguments are incorrect */
+    ARM_MATH_LENGTH_ERROR = -2,   /**< Length of data buffer is incorrect */
+    ARM_MATH_SIZE_MISMATCH = -3,  /**< Size of matrices is not compatible with the operation. */
+    ARM_MATH_NANINF = -4,         /**< Not-a-number (NaN) or infinity is generated */
+    ARM_MATH_SINGULAR = -5,       /**< Generated by matrix inversion if the input matrix is singular and cannot be inverted. */
+    ARM_MATH_TEST_FAILURE = -6    /**< Test Failed  */
   } arm_status;
 
   /**
@@ -440,118 +437,113 @@ extern "C"
   /**
    * @brief definition to read/write two 16 bit values.
    */
-#if   defined ( __CC_ARM )
-  #define __SIMD32_TYPE int32_t __packed
-  #define CMSIS_UNUSED __attribute__((unused))
-  #define CMSIS_INLINE __attribute__((always_inline))
+#if defined(__CC_ARM)
+#define __SIMD32_TYPE int32_t __packed
+#define CMSIS_UNUSED __attribute__((unused))
+#define CMSIS_INLINE __attribute__((always_inline))
 
-#elif defined ( __ARMCC_VERSION ) && ( __ARMCC_VERSION >= 6010050 )
-  #define __SIMD32_TYPE int32_t
-  #define CMSIS_UNUSED __attribute__((unused))
-  #define CMSIS_INLINE __attribute__((always_inline))
+#elif defined(__ARMCC_VERSION) && (__ARMCC_VERSION >= 6010050)
+#define __SIMD32_TYPE int32_t
+#define CMSIS_UNUSED __attribute__((unused))
+#define CMSIS_INLINE __attribute__((always_inline))
 
-#elif defined ( __GNUC__ )
-  #define __SIMD32_TYPE int32_t
-  #define CMSIS_UNUSED __attribute__((unused))
-  #define CMSIS_INLINE __attribute__((always_inline))
+#elif defined(__GNUC__)
+#define __SIMD32_TYPE int32_t
+#define CMSIS_UNUSED __attribute__((unused))
+#define CMSIS_INLINE __attribute__((always_inline))
 
-#elif defined ( __ICCARM__ )
-  #define __SIMD32_TYPE int32_t __packed
-  #define CMSIS_UNUSED
-  #define CMSIS_INLINE
+#elif defined(__ICCARM__)
+#define __SIMD32_TYPE int32_t __packed
+#define CMSIS_UNUSED
+#define CMSIS_INLINE
 
-#elif defined ( __TI_ARM__ )
-  #define __SIMD32_TYPE int32_t
-  #define CMSIS_UNUSED __attribute__((unused))
-  #define CMSIS_INLINE
+#elif defined(__TI_ARM__)
+#define __SIMD32_TYPE int32_t
+#define CMSIS_UNUSED __attribute__((unused))
+#define CMSIS_INLINE
 
-#elif defined ( __CSMC__ )
-  #define __SIMD32_TYPE int32_t
-  #define CMSIS_UNUSED
-  #define CMSIS_INLINE
+#elif defined(__CSMC__)
+#define __SIMD32_TYPE int32_t
+#define CMSIS_UNUSED
+#define CMSIS_INLINE
 
-#elif defined ( __TASKING__ )
-  #define __SIMD32_TYPE __unaligned int32_t
-  #define CMSIS_UNUSED
-  #define CMSIS_INLINE
+#elif defined(__TASKING__)
+#define __SIMD32_TYPE __unaligned int32_t
+#define CMSIS_UNUSED
+#define CMSIS_INLINE
 
 #else
-  #error Unknown compiler
+#error Unknown compiler
 #endif
 
-#define __SIMD32(addr)        (*(__SIMD32_TYPE **) & (addr))
-#define __SIMD32_CONST(addr)  ((__SIMD32_TYPE *)(addr))
-#define _SIMD32_OFFSET(addr)  (*(__SIMD32_TYPE *)  (addr))
-#define __SIMD64(addr)        (*(int64_t **) & (addr))
+#define __SIMD32(addr) (*(__SIMD32_TYPE **)&(addr))
+#define __SIMD32_CONST(addr) ((__SIMD32_TYPE *)(addr))
+#define _SIMD32_OFFSET(addr) (*(__SIMD32_TYPE *)(addr))
+#define __SIMD64(addr) (*(int64_t **)&(addr))
 
-#if !defined (ARM_MATH_DSP)
+#if !defined(ARM_MATH_DSP)
   /**
    * @brief definition to pack two 16 bit values.
    */
-#define __PKHBT(ARG1, ARG2, ARG3) ( (((int32_t)(ARG1) <<    0) & (int32_t)0x0000FFFF) | \
-                                    (((int32_t)(ARG2) << ARG3) & (int32_t)0xFFFF0000)  )
-#define __PKHTB(ARG1, ARG2, ARG3) ( (((int32_t)(ARG1) <<    0) & (int32_t)0xFFFF0000) | \
-                                    (((int32_t)(ARG2) >> ARG3) & (int32_t)0x0000FFFF)  )
+#define __PKHBT(ARG1, ARG2, ARG3) ((((int32_t)(ARG1) << 0) & (int32_t)0x0000FFFF) | \
+                                   (((int32_t)(ARG2) << ARG3) & (int32_t)0xFFFF0000))
+#define __PKHTB(ARG1, ARG2, ARG3) ((((int32_t)(ARG1) << 0) & (int32_t)0xFFFF0000) | \
+                                   (((int32_t)(ARG2) >> ARG3) & (int32_t)0x0000FFFF))
 
 #endif /* !defined (ARM_MATH_DSP) */
 
-   /**
+  /**
    * @brief definition to pack four 8 bit values.
    */
 #ifndef ARM_MATH_BIG_ENDIAN
 
-#define __PACKq7(v0,v1,v2,v3) ( (((int32_t)(v0) <<  0) & (int32_t)0x000000FF) | \
-                                (((int32_t)(v1) <<  8) & (int32_t)0x0000FF00) | \
-                                (((int32_t)(v2) << 16) & (int32_t)0x00FF0000) | \
-                                (((int32_t)(v3) << 24) & (int32_t)0xFF000000)  )
+#define __PACKq7(v0, v1, v2, v3) ((((int32_t)(v0) << 0) & (int32_t)0x000000FF) |  \
+                                  (((int32_t)(v1) << 8) & (int32_t)0x0000FF00) |  \
+                                  (((int32_t)(v2) << 16) & (int32_t)0x00FF0000) | \
+                                  (((int32_t)(v3) << 24) & (int32_t)0xFF000000))
 #else
 
-#define __PACKq7(v0,v1,v2,v3) ( (((int32_t)(v3) <<  0) & (int32_t)0x000000FF) | \
-                                (((int32_t)(v2) <<  8) & (int32_t)0x0000FF00) | \
-                                (((int32_t)(v1) << 16) & (int32_t)0x00FF0000) | \
-                                (((int32_t)(v0) << 24) & (int32_t)0xFF000000)  )
+#define __PACKq7(v0, v1, v2, v3) ((((int32_t)(v3) << 0) & (int32_t)0x000000FF) |  \
+                                  (((int32_t)(v2) << 8) & (int32_t)0x0000FF00) |  \
+                                  (((int32_t)(v1) << 16) & (int32_t)0x00FF0000) | \
+                                  (((int32_t)(v0) << 24) & (int32_t)0xFF000000))
 
 #endif
-
 
   /**
    * @brief Clips Q63 to Q31 values.
    */
   CMSIS_INLINE __STATIC_INLINE q31_t clip_q63_to_q31(
-  q63_t x)
+      q63_t x)
   {
-    return ((q31_t) (x >> 32) != ((q31_t) x >> 31)) ?
-      ((0x7FFFFFFF ^ ((q31_t) (x >> 63)))) : (q31_t) x;
+    return ((q31_t)(x >> 32) != ((q31_t)x >> 31)) ? ((0x7FFFFFFF ^ ((q31_t)(x >> 63)))) : (q31_t)x;
   }
 
   /**
    * @brief Clips Q63 to Q15 values.
    */
   CMSIS_INLINE __STATIC_INLINE q15_t clip_q63_to_q15(
-  q63_t x)
+      q63_t x)
   {
-    return ((q31_t) (x >> 32) != ((q31_t) x >> 31)) ?
-      ((0x7FFF ^ ((q15_t) (x >> 63)))) : (q15_t) (x >> 15);
+    return ((q31_t)(x >> 32) != ((q31_t)x >> 31)) ? ((0x7FFF ^ ((q15_t)(x >> 63)))) : (q15_t)(x >> 15);
   }
 
   /**
    * @brief Clips Q31 to Q7 values.
    */
   CMSIS_INLINE __STATIC_INLINE q7_t clip_q31_to_q7(
-  q31_t x)
+      q31_t x)
   {
-    return ((q31_t) (x >> 24) != ((q31_t) x >> 23)) ?
-      ((0x7F ^ ((q7_t) (x >> 31)))) : (q7_t) x;
+    return ((q31_t)(x >> 24) != ((q31_t)x >> 23)) ? ((0x7F ^ ((q7_t)(x >> 31)))) : (q7_t)x;
   }
 
   /**
    * @brief Clips Q31 to Q15 values.
    */
   CMSIS_INLINE __STATIC_INLINE q15_t clip_q31_to_q15(
-  q31_t x)
+      q31_t x)
   {
-    return ((q31_t) (x >> 16) != ((q31_t) x >> 15)) ?
-      ((0x7FFF ^ ((q15_t) (x >> 31)))) : (q15_t) x;
+    return ((q31_t)(x >> 16) != ((q31_t)x >> 15)) ? ((0x7FFF ^ ((q15_t)(x >> 31)))) : (q15_t)x;
   }
 
   /**
@@ -559,11 +551,11 @@ extern "C"
    */
 
   CMSIS_INLINE __STATIC_INLINE q63_t mult32x64(
-  q63_t x,
-  q31_t y)
+      q63_t x,
+      q31_t y)
   {
-    return ((((q63_t) (x & 0x00000000FFFFFFFF) * y) >> 32) +
-            (((q63_t) (x >> 32) * y)));
+    return ((((q63_t)(x & 0x00000000FFFFFFFF) * y) >> 32) +
+            (((q63_t)(x >> 32) * y)));
   }
 
   /**
@@ -571,9 +563,9 @@ extern "C"
    */
 
   CMSIS_INLINE __STATIC_INLINE uint32_t arm_recip_q31(
-  q31_t in,
-  q31_t * dst,
-  q31_t * pRecipTable)
+      q31_t in,
+      q31_t *dst,
+      q31_t *pRecipTable)
   {
     q31_t out;
     uint32_t tempVal;
@@ -582,11 +574,11 @@ extern "C"
 
     if (in > 0)
     {
-      signBits = ((uint32_t) (__CLZ( in) - 1));
+      signBits = ((uint32_t)(__CLZ(in) - 1));
     }
     else
     {
-      signBits = ((uint32_t) (__CLZ(-in) - 1));
+      signBits = ((uint32_t)(__CLZ(-in) - 1));
     }
 
     /* Convert input sample to 1.31 format */
@@ -603,11 +595,11 @@ extern "C"
     /* running approximation for two iterations */
     for (i = 0U; i < 2U; i++)
     {
-      tempVal = (uint32_t) (((q63_t) in * out) >> 31);
+      tempVal = (uint32_t)(((q63_t)in * out) >> 31);
       tempVal = 0x7FFFFFFFu - tempVal;
       /*      1.31 with exp 1 */
       /* out = (q31_t) (((q63_t) out * tempVal) >> 30); */
-      out = clip_q63_to_q31(((q63_t) out * tempVal) >> 30);
+      out = clip_q63_to_q31(((q63_t)out * tempVal) >> 30);
     }
 
     /* write output */
@@ -617,14 +609,13 @@ extern "C"
     return (signBits + 1U);
   }
 
-
   /**
    * @brief Function to Calculates 1/in (reciprocal) value of Q15 Data type.
    */
   CMSIS_INLINE __STATIC_INLINE uint32_t arm_recip_q15(
-  q15_t in,
-  q15_t * dst,
-  q15_t * pRecipTable)
+      q15_t in,
+      q15_t *dst,
+      q15_t *pRecipTable)
   {
     q15_t out = 0;
     uint32_t tempVal = 0;
@@ -633,7 +624,7 @@ extern "C"
 
     if (in > 0)
     {
-      signBits = ((uint32_t)(__CLZ( in) - 17));
+      signBits = ((uint32_t)(__CLZ(in) - 17));
     }
     else
     {
@@ -644,7 +635,7 @@ extern "C"
     in = (in << signBits);
 
     /* calculation of index for initial approximated Val */
-    index = (uint32_t)(in >>  8);
+    index = (uint32_t)(in >> 8);
     index = (index & INDEX_MASK);
 
     /*      1.15 with exp 1  */
@@ -654,10 +645,10 @@ extern "C"
     /* running approximation for two iterations */
     for (i = 0U; i < 2U; i++)
     {
-      tempVal = (uint32_t) (((q31_t) in * out) >> 15);
+      tempVal = (uint32_t)(((q31_t)in * out) >> 15);
       tempVal = 0x7FFFu - tempVal;
       /*      1.15 with exp 1 */
-      out = (q15_t) (((q31_t) out * tempVal) >> 14);
+      out = (q15_t)(((q31_t)out * tempVal) >> 14);
       /* out = clip_q31_to_q15(((q31_t) out * tempVal) >> 14); */
     }
 
@@ -668,350 +659,328 @@ extern "C"
     return (signBits + 1);
   }
 
-
 /*
  * @brief C custom defined intrinsic function for M3 and M0 processors
  */
-#if !defined (ARM_MATH_DSP)
+#if !defined(ARM_MATH_DSP)
 
   /*
    * @brief C custom defined QADD8 for M3 and M0 processors
    */
   CMSIS_INLINE __STATIC_INLINE uint32_t __QADD8(
-  uint32_t x,
-  uint32_t y)
+      uint32_t x,
+      uint32_t y)
   {
     q31_t r, s, t, u;
 
     r = __SSAT(((((q31_t)x << 24) >> 24) + (((q31_t)y << 24) >> 24)), 8) & (int32_t)0x000000FF;
     s = __SSAT(((((q31_t)x << 16) >> 24) + (((q31_t)y << 16) >> 24)), 8) & (int32_t)0x000000FF;
-    t = __SSAT(((((q31_t)x <<  8) >> 24) + (((q31_t)y <<  8) >> 24)), 8) & (int32_t)0x000000FF;
-    u = __SSAT(((((q31_t)x      ) >> 24) + (((q31_t)y      ) >> 24)), 8) & (int32_t)0x000000FF;
+    t = __SSAT(((((q31_t)x << 8) >> 24) + (((q31_t)y << 8) >> 24)), 8) & (int32_t)0x000000FF;
+    u = __SSAT(((((q31_t)x) >> 24) + (((q31_t)y) >> 24)), 8) & (int32_t)0x000000FF;
 
-    return ((uint32_t)((u << 24) | (t << 16) | (s <<  8) | (r      )));
+    return ((uint32_t)((u << 24) | (t << 16) | (s << 8) | (r)));
   }
-
 
   /*
    * @brief C custom defined QSUB8 for M3 and M0 processors
    */
   CMSIS_INLINE __STATIC_INLINE uint32_t __QSUB8(
-  uint32_t x,
-  uint32_t y)
+      uint32_t x,
+      uint32_t y)
   {
     q31_t r, s, t, u;
 
     r = __SSAT(((((q31_t)x << 24) >> 24) - (((q31_t)y << 24) >> 24)), 8) & (int32_t)0x000000FF;
     s = __SSAT(((((q31_t)x << 16) >> 24) - (((q31_t)y << 16) >> 24)), 8) & (int32_t)0x000000FF;
-    t = __SSAT(((((q31_t)x <<  8) >> 24) - (((q31_t)y <<  8) >> 24)), 8) & (int32_t)0x000000FF;
-    u = __SSAT(((((q31_t)x      ) >> 24) - (((q31_t)y      ) >> 24)), 8) & (int32_t)0x000000FF;
+    t = __SSAT(((((q31_t)x << 8) >> 24) - (((q31_t)y << 8) >> 24)), 8) & (int32_t)0x000000FF;
+    u = __SSAT(((((q31_t)x) >> 24) - (((q31_t)y) >> 24)), 8) & (int32_t)0x000000FF;
 
-    return ((uint32_t)((u << 24) | (t << 16) | (s <<  8) | (r      )));
+    return ((uint32_t)((u << 24) | (t << 16) | (s << 8) | (r)));
   }
-
 
   /*
    * @brief C custom defined QADD16 for M3 and M0 processors
    */
   CMSIS_INLINE __STATIC_INLINE uint32_t __QADD16(
-  uint32_t x,
-  uint32_t y)
+      uint32_t x,
+      uint32_t y)
   {
-/*  q31_t r,     s;  without initialisation 'arm_offset_q15 test' fails  but 'intrinsic' tests pass! for armCC */
+    /*  q31_t r,     s;  without initialisation 'arm_offset_q15 test' fails  but 'intrinsic' tests pass! for armCC */
     q31_t r = 0, s = 0;
 
     r = __SSAT(((((q31_t)x << 16) >> 16) + (((q31_t)y << 16) >> 16)), 16) & (int32_t)0x0000FFFF;
-    s = __SSAT(((((q31_t)x      ) >> 16) + (((q31_t)y      ) >> 16)), 16) & (int32_t)0x0000FFFF;
+    s = __SSAT(((((q31_t)x) >> 16) + (((q31_t)y) >> 16)), 16) & (int32_t)0x0000FFFF;
 
-    return ((uint32_t)((s << 16) | (r      )));
+    return ((uint32_t)((s << 16) | (r)));
   }
-
 
   /*
    * @brief C custom defined SHADD16 for M3 and M0 processors
    */
   CMSIS_INLINE __STATIC_INLINE uint32_t __SHADD16(
-  uint32_t x,
-  uint32_t y)
+      uint32_t x,
+      uint32_t y)
   {
     q31_t r, s;
 
     r = (((((q31_t)x << 16) >> 16) + (((q31_t)y << 16) >> 16)) >> 1) & (int32_t)0x0000FFFF;
-    s = (((((q31_t)x      ) >> 16) + (((q31_t)y      ) >> 16)) >> 1) & (int32_t)0x0000FFFF;
+    s = (((((q31_t)x) >> 16) + (((q31_t)y) >> 16)) >> 1) & (int32_t)0x0000FFFF;
 
-    return ((uint32_t)((s << 16) | (r      )));
+    return ((uint32_t)((s << 16) | (r)));
   }
-
 
   /*
    * @brief C custom defined QSUB16 for M3 and M0 processors
    */
   CMSIS_INLINE __STATIC_INLINE uint32_t __QSUB16(
-  uint32_t x,
-  uint32_t y)
+      uint32_t x,
+      uint32_t y)
   {
     q31_t r, s;
 
     r = __SSAT(((((q31_t)x << 16) >> 16) - (((q31_t)y << 16) >> 16)), 16) & (int32_t)0x0000FFFF;
-    s = __SSAT(((((q31_t)x      ) >> 16) - (((q31_t)y      ) >> 16)), 16) & (int32_t)0x0000FFFF;
+    s = __SSAT(((((q31_t)x) >> 16) - (((q31_t)y) >> 16)), 16) & (int32_t)0x0000FFFF;
 
-    return ((uint32_t)((s << 16) | (r      )));
+    return ((uint32_t)((s << 16) | (r)));
   }
-
 
   /*
    * @brief C custom defined SHSUB16 for M3 and M0 processors
    */
   CMSIS_INLINE __STATIC_INLINE uint32_t __SHSUB16(
-  uint32_t x,
-  uint32_t y)
+      uint32_t x,
+      uint32_t y)
   {
     q31_t r, s;
 
     r = (((((q31_t)x << 16) >> 16) - (((q31_t)y << 16) >> 16)) >> 1) & (int32_t)0x0000FFFF;
-    s = (((((q31_t)x      ) >> 16) - (((q31_t)y      ) >> 16)) >> 1) & (int32_t)0x0000FFFF;
+    s = (((((q31_t)x) >> 16) - (((q31_t)y) >> 16)) >> 1) & (int32_t)0x0000FFFF;
 
-    return ((uint32_t)((s << 16) | (r      )));
+    return ((uint32_t)((s << 16) | (r)));
   }
-
 
   /*
    * @brief C custom defined QASX for M3 and M0 processors
    */
   CMSIS_INLINE __STATIC_INLINE uint32_t __QASX(
-  uint32_t x,
-  uint32_t y)
+      uint32_t x,
+      uint32_t y)
   {
     q31_t r, s;
 
-    r = __SSAT(((((q31_t)x << 16) >> 16) - (((q31_t)y      ) >> 16)), 16) & (int32_t)0x0000FFFF;
-    s = __SSAT(((((q31_t)x      ) >> 16) + (((q31_t)y << 16) >> 16)), 16) & (int32_t)0x0000FFFF;
+    r = __SSAT(((((q31_t)x << 16) >> 16) - (((q31_t)y) >> 16)), 16) & (int32_t)0x0000FFFF;
+    s = __SSAT(((((q31_t)x) >> 16) + (((q31_t)y << 16) >> 16)), 16) & (int32_t)0x0000FFFF;
 
-    return ((uint32_t)((s << 16) | (r      )));
+    return ((uint32_t)((s << 16) | (r)));
   }
-
 
   /*
    * @brief C custom defined SHASX for M3 and M0 processors
    */
   CMSIS_INLINE __STATIC_INLINE uint32_t __SHASX(
-  uint32_t x,
-  uint32_t y)
+      uint32_t x,
+      uint32_t y)
   {
     q31_t r, s;
 
-    r = (((((q31_t)x << 16) >> 16) - (((q31_t)y      ) >> 16)) >> 1) & (int32_t)0x0000FFFF;
-    s = (((((q31_t)x      ) >> 16) + (((q31_t)y << 16) >> 16)) >> 1) & (int32_t)0x0000FFFF;
+    r = (((((q31_t)x << 16) >> 16) - (((q31_t)y) >> 16)) >> 1) & (int32_t)0x0000FFFF;
+    s = (((((q31_t)x) >> 16) + (((q31_t)y << 16) >> 16)) >> 1) & (int32_t)0x0000FFFF;
 
-    return ((uint32_t)((s << 16) | (r      )));
+    return ((uint32_t)((s << 16) | (r)));
   }
-
 
   /*
    * @brief C custom defined QSAX for M3 and M0 processors
    */
   CMSIS_INLINE __STATIC_INLINE uint32_t __QSAX(
-  uint32_t x,
-  uint32_t y)
+      uint32_t x,
+      uint32_t y)
   {
     q31_t r, s;
 
-    r = __SSAT(((((q31_t)x << 16) >> 16) + (((q31_t)y      ) >> 16)), 16) & (int32_t)0x0000FFFF;
-    s = __SSAT(((((q31_t)x      ) >> 16) - (((q31_t)y << 16) >> 16)), 16) & (int32_t)0x0000FFFF;
+    r = __SSAT(((((q31_t)x << 16) >> 16) + (((q31_t)y) >> 16)), 16) & (int32_t)0x0000FFFF;
+    s = __SSAT(((((q31_t)x) >> 16) - (((q31_t)y << 16) >> 16)), 16) & (int32_t)0x0000FFFF;
 
-    return ((uint32_t)((s << 16) | (r      )));
+    return ((uint32_t)((s << 16) | (r)));
   }
-
 
   /*
    * @brief C custom defined SHSAX for M3 and M0 processors
    */
   CMSIS_INLINE __STATIC_INLINE uint32_t __SHSAX(
-  uint32_t x,
-  uint32_t y)
+      uint32_t x,
+      uint32_t y)
   {
     q31_t r, s;
 
-    r = (((((q31_t)x << 16) >> 16) + (((q31_t)y      ) >> 16)) >> 1) & (int32_t)0x0000FFFF;
-    s = (((((q31_t)x      ) >> 16) - (((q31_t)y << 16) >> 16)) >> 1) & (int32_t)0x0000FFFF;
+    r = (((((q31_t)x << 16) >> 16) + (((q31_t)y) >> 16)) >> 1) & (int32_t)0x0000FFFF;
+    s = (((((q31_t)x) >> 16) - (((q31_t)y << 16) >> 16)) >> 1) & (int32_t)0x0000FFFF;
 
-    return ((uint32_t)((s << 16) | (r      )));
+    return ((uint32_t)((s << 16) | (r)));
   }
-
 
   /*
    * @brief C custom defined SMUSDX for M3 and M0 processors
    */
   CMSIS_INLINE __STATIC_INLINE uint32_t __SMUSDX(
-  uint32_t x,
-  uint32_t y)
+      uint32_t x,
+      uint32_t y)
   {
-    return ((uint32_t)(((((q31_t)x << 16) >> 16) * (((q31_t)y      ) >> 16)) -
-                       ((((q31_t)x      ) >> 16) * (((q31_t)y << 16) >> 16))   ));
+    return ((uint32_t)(((((q31_t)x << 16) >> 16) * (((q31_t)y) >> 16)) -
+                       ((((q31_t)x) >> 16) * (((q31_t)y << 16) >> 16))));
   }
 
   /*
    * @brief C custom defined SMUADX for M3 and M0 processors
    */
   CMSIS_INLINE __STATIC_INLINE uint32_t __SMUADX(
-  uint32_t x,
-  uint32_t y)
+      uint32_t x,
+      uint32_t y)
   {
-    return ((uint32_t)(((((q31_t)x << 16) >> 16) * (((q31_t)y      ) >> 16)) +
-                       ((((q31_t)x      ) >> 16) * (((q31_t)y << 16) >> 16))   ));
+    return ((uint32_t)(((((q31_t)x << 16) >> 16) * (((q31_t)y) >> 16)) +
+                       ((((q31_t)x) >> 16) * (((q31_t)y << 16) >> 16))));
   }
-
 
   /*
    * @brief C custom defined QADD for M3 and M0 processors
    */
   CMSIS_INLINE __STATIC_INLINE int32_t __QADD(
-  int32_t x,
-  int32_t y)
+      int32_t x,
+      int32_t y)
   {
     return ((int32_t)(clip_q63_to_q31((q63_t)x + (q31_t)y)));
   }
-
 
   /*
    * @brief C custom defined QSUB for M3 and M0 processors
    */
   CMSIS_INLINE __STATIC_INLINE int32_t __QSUB(
-  int32_t x,
-  int32_t y)
+      int32_t x,
+      int32_t y)
   {
     return ((int32_t)(clip_q63_to_q31((q63_t)x - (q31_t)y)));
   }
-
 
   /*
    * @brief C custom defined SMLAD for M3 and M0 processors
    */
   CMSIS_INLINE __STATIC_INLINE uint32_t __SMLAD(
-  uint32_t x,
-  uint32_t y,
-  uint32_t sum)
+      uint32_t x,
+      uint32_t y,
+      uint32_t sum)
   {
     return ((uint32_t)(((((q31_t)x << 16) >> 16) * (((q31_t)y << 16) >> 16)) +
-                       ((((q31_t)x      ) >> 16) * (((q31_t)y      ) >> 16)) +
-                       ( ((q31_t)sum    )                                  )   ));
+                       ((((q31_t)x) >> 16) * (((q31_t)y) >> 16)) +
+                       (((q31_t)sum))));
   }
-
 
   /*
    * @brief C custom defined SMLADX for M3 and M0 processors
    */
   CMSIS_INLINE __STATIC_INLINE uint32_t __SMLADX(
-  uint32_t x,
-  uint32_t y,
-  uint32_t sum)
+      uint32_t x,
+      uint32_t y,
+      uint32_t sum)
   {
-    return ((uint32_t)(((((q31_t)x << 16) >> 16) * (((q31_t)y      ) >> 16)) +
-                       ((((q31_t)x      ) >> 16) * (((q31_t)y << 16) >> 16)) +
-                       ( ((q31_t)sum    )                                  )   ));
+    return ((uint32_t)(((((q31_t)x << 16) >> 16) * (((q31_t)y) >> 16)) +
+                       ((((q31_t)x) >> 16) * (((q31_t)y << 16) >> 16)) +
+                       (((q31_t)sum))));
   }
-
 
   /*
    * @brief C custom defined SMLSDX for M3 and M0 processors
    */
   CMSIS_INLINE __STATIC_INLINE uint32_t __SMLSDX(
-  uint32_t x,
-  uint32_t y,
-  uint32_t sum)
+      uint32_t x,
+      uint32_t y,
+      uint32_t sum)
   {
-    return ((uint32_t)(((((q31_t)x << 16) >> 16) * (((q31_t)y      ) >> 16)) -
-                       ((((q31_t)x      ) >> 16) * (((q31_t)y << 16) >> 16)) +
-                       ( ((q31_t)sum    )                                  )   ));
+    return ((uint32_t)(((((q31_t)x << 16) >> 16) * (((q31_t)y) >> 16)) -
+                       ((((q31_t)x) >> 16) * (((q31_t)y << 16) >> 16)) +
+                       (((q31_t)sum))));
   }
-
 
   /*
    * @brief C custom defined SMLALD for M3 and M0 processors
    */
   CMSIS_INLINE __STATIC_INLINE uint64_t __SMLALD(
-  uint32_t x,
-  uint32_t y,
-  uint64_t sum)
+      uint32_t x,
+      uint32_t y,
+      uint64_t sum)
   {
-/*  return (sum + ((q15_t) (x >> 16) * (q15_t) (y >> 16)) + ((q15_t) x * (q15_t) y)); */
+    /*  return (sum + ((q15_t) (x >> 16) * (q15_t) (y >> 16)) + ((q15_t) x * (q15_t) y)); */
     return ((uint64_t)(((((q31_t)x << 16) >> 16) * (((q31_t)y << 16) >> 16)) +
-                       ((((q31_t)x      ) >> 16) * (((q31_t)y      ) >> 16)) +
-                       ( ((q63_t)sum    )                                  )   ));
+                       ((((q31_t)x) >> 16) * (((q31_t)y) >> 16)) +
+                       (((q63_t)sum))));
   }
-
 
   /*
    * @brief C custom defined SMLALDX for M3 and M0 processors
    */
   CMSIS_INLINE __STATIC_INLINE uint64_t __SMLALDX(
-  uint32_t x,
-  uint32_t y,
-  uint64_t sum)
+      uint32_t x,
+      uint32_t y,
+      uint64_t sum)
   {
-/*  return (sum + ((q15_t) (x >> 16) * (q15_t) y)) + ((q15_t) x * (q15_t) (y >> 16)); */
-    return ((uint64_t)(((((q31_t)x << 16) >> 16) * (((q31_t)y      ) >> 16)) +
-                       ((((q31_t)x      ) >> 16) * (((q31_t)y << 16) >> 16)) +
-                       ( ((q63_t)sum    )                                  )   ));
+    /*  return (sum + ((q15_t) (x >> 16) * (q15_t) y)) + ((q15_t) x * (q15_t) (y >> 16)); */
+    return ((uint64_t)(((((q31_t)x << 16) >> 16) * (((q31_t)y) >> 16)) +
+                       ((((q31_t)x) >> 16) * (((q31_t)y << 16) >> 16)) +
+                       (((q63_t)sum))));
   }
-
 
   /*
    * @brief C custom defined SMUAD for M3 and M0 processors
    */
   CMSIS_INLINE __STATIC_INLINE uint32_t __SMUAD(
-  uint32_t x,
-  uint32_t y)
+      uint32_t x,
+      uint32_t y)
   {
     return ((uint32_t)(((((q31_t)x << 16) >> 16) * (((q31_t)y << 16) >> 16)) +
-                       ((((q31_t)x      ) >> 16) * (((q31_t)y      ) >> 16))   ));
+                       ((((q31_t)x) >> 16) * (((q31_t)y) >> 16))));
   }
-
 
   /*
    * @brief C custom defined SMUSD for M3 and M0 processors
    */
   CMSIS_INLINE __STATIC_INLINE uint32_t __SMUSD(
-  uint32_t x,
-  uint32_t y)
+      uint32_t x,
+      uint32_t y)
   {
     return ((uint32_t)(((((q31_t)x << 16) >> 16) * (((q31_t)y << 16) >> 16)) -
-                       ((((q31_t)x      ) >> 16) * (((q31_t)y      ) >> 16))   ));
+                       ((((q31_t)x) >> 16) * (((q31_t)y) >> 16))));
   }
-
 
   /*
    * @brief C custom defined SXTB16 for M3 and M0 processors
    */
   CMSIS_INLINE __STATIC_INLINE uint32_t __SXTB16(
-  uint32_t x)
+      uint32_t x)
   {
     return ((uint32_t)(((((q31_t)x << 24) >> 24) & (q31_t)0x0000FFFF) |
-                       ((((q31_t)x <<  8) >>  8) & (q31_t)0xFFFF0000)  ));
+                       ((((q31_t)x << 8) >> 8) & (q31_t)0xFFFF0000)));
   }
 
   /*
    * @brief C custom defined SMMLA for M3 and M0 processors
    */
   CMSIS_INLINE __STATIC_INLINE int32_t __SMMLA(
-  int32_t x,
-  int32_t y,
-  int32_t sum)
+      int32_t x,
+      int32_t y,
+      int32_t sum)
   {
-    return (sum + (int32_t) (((int64_t) x * y) >> 32));
+    return (sum + (int32_t)(((int64_t)x * y) >> 32));
   }
 
 #endif /* !defined (ARM_MATH_DSP) */
-
 
   /**
    * @brief Instance structure for the Q7 FIR filter.
    */
   typedef struct
   {
-    uint16_t numTaps;        /**< number of filter coefficients in the filter. */
-    q7_t *pState;            /**< points to the state variable array. The array is of length numTaps+blockSize-1. */
-    q7_t *pCoeffs;           /**< points to the coefficient array. The array is of length numTaps.*/
+    uint16_t numTaps; /**< number of filter coefficients in the filter. */
+    q7_t *pState;     /**< points to the state variable array. The array is of length numTaps+blockSize-1. */
+    q7_t *pCoeffs;    /**< points to the coefficient array. The array is of length numTaps.*/
   } arm_fir_instance_q7;
 
   /**
@@ -1019,9 +988,9 @@ extern "C"
    */
   typedef struct
   {
-    uint16_t numTaps;         /**< number of filter coefficients in the filter. */
-    q15_t *pState;            /**< points to the state variable array. The array is of length numTaps+blockSize-1. */
-    q15_t *pCoeffs;           /**< points to the coefficient array. The array is of length numTaps.*/
+    uint16_t numTaps; /**< number of filter coefficients in the filter. */
+    q15_t *pState;    /**< points to the state variable array. The array is of length numTaps+blockSize-1. */
+    q15_t *pCoeffs;   /**< points to the coefficient array. The array is of length numTaps.*/
   } arm_fir_instance_q15;
 
   /**
@@ -1029,9 +998,9 @@ extern "C"
    */
   typedef struct
   {
-    uint16_t numTaps;         /**< number of filter coefficients in the filter. */
-    q31_t *pState;            /**< points to the state variable array. The array is of length numTaps+blockSize-1. */
-    q31_t *pCoeffs;           /**< points to the coefficient array. The array is of length numTaps. */
+    uint16_t numTaps; /**< number of filter coefficients in the filter. */
+    q31_t *pState;    /**< points to the state variable array. The array is of length numTaps+blockSize-1. */
+    q31_t *pCoeffs;   /**< points to the coefficient array. The array is of length numTaps. */
   } arm_fir_instance_q31;
 
   /**
@@ -1039,11 +1008,10 @@ extern "C"
    */
   typedef struct
   {
-    uint16_t numTaps;     /**< number of filter coefficients in the filter. */
-    float32_t *pState;    /**< points to the state variable array. The array is of length numTaps+blockSize-1. */
-    float32_t *pCoeffs;   /**< points to the coefficient array. The array is of length numTaps. */
+    uint16_t numTaps;   /**< number of filter coefficients in the filter. */
+    float32_t *pState;  /**< points to the state variable array. The array is of length numTaps+blockSize-1. */
+    float32_t *pCoeffs; /**< points to the coefficient array. The array is of length numTaps. */
   } arm_fir_instance_f32;
-
 
   /**
    * @brief Processing function for the Q7 FIR filter.
@@ -1053,11 +1021,10 @@ extern "C"
    * @param[in]  blockSize  number of samples to process.
    */
   void arm_fir_q7(
-  const arm_fir_instance_q7 * S,
-  q7_t * pSrc,
-  q7_t * pDst,
-  uint32_t blockSize);
-
+      const arm_fir_instance_q7 *S,
+      q7_t *pSrc,
+      q7_t *pDst,
+      uint32_t blockSize);
 
   /**
    * @brief  Initialization function for the Q7 FIR filter.
@@ -1068,12 +1035,11 @@ extern "C"
    * @param[in]     blockSize  number of samples that are processed.
    */
   void arm_fir_init_q7(
-  arm_fir_instance_q7 * S,
-  uint16_t numTaps,
-  q7_t * pCoeffs,
-  q7_t * pState,
-  uint32_t blockSize);
-
+      arm_fir_instance_q7 *S,
+      uint16_t numTaps,
+      q7_t *pCoeffs,
+      q7_t *pState,
+      uint32_t blockSize);
 
   /**
    * @brief Processing function for the Q15 FIR filter.
@@ -1083,11 +1049,10 @@ extern "C"
    * @param[in]  blockSize  number of samples to process.
    */
   void arm_fir_q15(
-  const arm_fir_instance_q15 * S,
-  q15_t * pSrc,
-  q15_t * pDst,
-  uint32_t blockSize);
-
+      const arm_fir_instance_q15 *S,
+      q15_t *pSrc,
+      q15_t *pDst,
+      uint32_t blockSize);
 
   /**
    * @brief Processing function for the fast Q15 FIR filter for Cortex-M3 and Cortex-M4.
@@ -1097,11 +1062,10 @@ extern "C"
    * @param[in]  blockSize  number of samples to process.
    */
   void arm_fir_fast_q15(
-  const arm_fir_instance_q15 * S,
-  q15_t * pSrc,
-  q15_t * pDst,
-  uint32_t blockSize);
-
+      const arm_fir_instance_q15 *S,
+      q15_t *pSrc,
+      q15_t *pDst,
+      uint32_t blockSize);
 
   /**
    * @brief  Initialization function for the Q15 FIR filter.
@@ -1114,12 +1078,11 @@ extern "C"
    * <code>numTaps</code> is not a supported value.
    */
   arm_status arm_fir_init_q15(
-  arm_fir_instance_q15 * S,
-  uint16_t numTaps,
-  q15_t * pCoeffs,
-  q15_t * pState,
-  uint32_t blockSize);
-
+      arm_fir_instance_q15 *S,
+      uint16_t numTaps,
+      q15_t *pCoeffs,
+      q15_t *pState,
+      uint32_t blockSize);
 
   /**
    * @brief Processing function for the Q31 FIR filter.
@@ -1129,11 +1092,10 @@ extern "C"
    * @param[in]  blockSize  number of samples to process.
    */
   void arm_fir_q31(
-  const arm_fir_instance_q31 * S,
-  q31_t * pSrc,
-  q31_t * pDst,
-  uint32_t blockSize);
-
+      const arm_fir_instance_q31 *S,
+      q31_t *pSrc,
+      q31_t *pDst,
+      uint32_t blockSize);
 
   /**
    * @brief Processing function for the fast Q31 FIR filter for Cortex-M3 and Cortex-M4.
@@ -1143,11 +1105,10 @@ extern "C"
    * @param[in]  blockSize  number of samples to process.
    */
   void arm_fir_fast_q31(
-  const arm_fir_instance_q31 * S,
-  q31_t * pSrc,
-  q31_t * pDst,
-  uint32_t blockSize);
-
+      const arm_fir_instance_q31 *S,
+      q31_t *pSrc,
+      q31_t *pDst,
+      uint32_t blockSize);
 
   /**
    * @brief  Initialization function for the Q31 FIR filter.
@@ -1158,12 +1119,11 @@ extern "C"
    * @param[in]     blockSize  number of samples that are processed at a time.
    */
   void arm_fir_init_q31(
-  arm_fir_instance_q31 * S,
-  uint16_t numTaps,
-  q31_t * pCoeffs,
-  q31_t * pState,
-  uint32_t blockSize);
-
+      arm_fir_instance_q31 *S,
+      uint16_t numTaps,
+      q31_t *pCoeffs,
+      q31_t *pState,
+      uint32_t blockSize);
 
   /**
    * @brief Processing function for the floating-point FIR filter.
@@ -1173,11 +1133,10 @@ extern "C"
    * @param[in]  blockSize  number of samples to process.
    */
   void arm_fir_f32(
-  const arm_fir_instance_f32 * S,
-  float32_t * pSrc,
-  float32_t * pDst,
-  uint32_t blockSize);
-
+      const arm_fir_instance_f32 *S,
+      float32_t *pSrc,
+      float32_t *pDst,
+      uint32_t blockSize);
 
   /**
    * @brief  Initialization function for the floating-point FIR filter.
@@ -1188,22 +1147,21 @@ extern "C"
    * @param[in]     blockSize  number of samples that are processed at a time.
    */
   void arm_fir_init_f32(
-  arm_fir_instance_f32 * S,
-  uint16_t numTaps,
-  float32_t * pCoeffs,
-  float32_t * pState,
-  uint32_t blockSize);
-
+      arm_fir_instance_f32 *S,
+      uint16_t numTaps,
+      float32_t *pCoeffs,
+      float32_t *pState,
+      uint32_t blockSize);
 
   /**
    * @brief Instance structure for the Q15 Biquad cascade filter.
    */
   typedef struct
   {
-    int8_t numStages;        /**< number of 2nd order stages in the filter.  Overall order is 2*numStages. */
-    q15_t *pState;           /**< Points to the array of state coefficients.  The array is of length 4*numStages. */
-    q15_t *pCoeffs;          /**< Points to the array of coefficients.  The array is of length 5*numStages. */
-    int8_t postShift;        /**< Additional shift, in bits, applied to each output sample. */
+    int8_t numStages; /**< number of 2nd order stages in the filter.  Overall order is 2*numStages. */
+    q15_t *pState;    /**< Points to the array of state coefficients.  The array is of length 4*numStages. */
+    q15_t *pCoeffs;   /**< Points to the array of coefficients.  The array is of length 5*numStages. */
+    int8_t postShift; /**< Additional shift, in bits, applied to each output sample. */
   } arm_biquad_casd_df1_inst_q15;
 
   /**
@@ -1211,10 +1169,10 @@ extern "C"
    */
   typedef struct
   {
-    uint32_t numStages;      /**< number of 2nd order stages in the filter.  Overall order is 2*numStages. */
-    q31_t *pState;           /**< Points to the array of state coefficients.  The array is of length 4*numStages. */
-    q31_t *pCoeffs;          /**< Points to the array of coefficients.  The array is of length 5*numStages. */
-    uint8_t postShift;       /**< Additional shift, in bits, applied to each output sample. */
+    uint32_t numStages; /**< number of 2nd order stages in the filter.  Overall order is 2*numStages. */
+    q31_t *pState;      /**< Points to the array of state coefficients.  The array is of length 4*numStages. */
+    q31_t *pCoeffs;     /**< Points to the array of coefficients.  The array is of length 5*numStages. */
+    uint8_t postShift;  /**< Additional shift, in bits, applied to each output sample. */
   } arm_biquad_casd_df1_inst_q31;
 
   /**
@@ -1222,11 +1180,10 @@ extern "C"
    */
   typedef struct
   {
-    uint32_t numStages;      /**< number of 2nd order stages in the filter.  Overall order is 2*numStages. */
-    float32_t *pState;       /**< Points to the array of state coefficients.  The array is of length 4*numStages. */
-    float32_t *pCoeffs;      /**< Points to the array of coefficients.  The array is of length 5*numStages. */
+    uint32_t numStages; /**< number of 2nd order stages in the filter.  Overall order is 2*numStages. */
+    float32_t *pState;  /**< Points to the array of state coefficients.  The array is of length 4*numStages. */
+    float32_t *pCoeffs; /**< Points to the array of coefficients.  The array is of length 5*numStages. */
   } arm_biquad_casd_df1_inst_f32;
-
 
   /**
    * @brief Processing function for the Q15 Biquad cascade filter.
@@ -1236,11 +1193,10 @@ extern "C"
    * @param[in]  blockSize  number of samples to process.
    */
   void arm_biquad_cascade_df1_q15(
-  const arm_biquad_casd_df1_inst_q15 * S,
-  q15_t * pSrc,
-  q15_t * pDst,
-  uint32_t blockSize);
-
+      const arm_biquad_casd_df1_inst_q15 *S,
+      q15_t *pSrc,
+      q15_t *pDst,
+      uint32_t blockSize);
 
   /**
    * @brief  Initialization function for the Q15 Biquad cascade filter.
@@ -1251,12 +1207,11 @@ extern "C"
    * @param[in]     postShift  Shift to be applied to the output. Varies according to the coefficients format
    */
   void arm_biquad_cascade_df1_init_q15(
-  arm_biquad_casd_df1_inst_q15 * S,
-  uint8_t numStages,
-  q15_t * pCoeffs,
-  q15_t * pState,
-  int8_t postShift);
-
+      arm_biquad_casd_df1_inst_q15 *S,
+      uint8_t numStages,
+      q15_t *pCoeffs,
+      q15_t *pState,
+      int8_t postShift);
 
   /**
    * @brief Fast but less precise processing function for the Q15 Biquad cascade filter for Cortex-M3 and Cortex-M4.
@@ -1266,11 +1221,10 @@ extern "C"
    * @param[in]  blockSize  number of samples to process.
    */
   void arm_biquad_cascade_df1_fast_q15(
-  const arm_biquad_casd_df1_inst_q15 * S,
-  q15_t * pSrc,
-  q15_t * pDst,
-  uint32_t blockSize);
-
+      const arm_biquad_casd_df1_inst_q15 *S,
+      q15_t *pSrc,
+      q15_t *pDst,
+      uint32_t blockSize);
 
   /**
    * @brief Processing function for the Q31 Biquad cascade filter
@@ -1280,11 +1234,10 @@ extern "C"
    * @param[in]  blockSize  number of samples to process.
    */
   void arm_biquad_cascade_df1_q31(
-  const arm_biquad_casd_df1_inst_q31 * S,
-  q31_t * pSrc,
-  q31_t * pDst,
-  uint32_t blockSize);
-
+      const arm_biquad_casd_df1_inst_q31 *S,
+      q31_t *pSrc,
+      q31_t *pDst,
+      uint32_t blockSize);
 
   /**
    * @brief Fast but less precise processing function for the Q31 Biquad cascade filter for Cortex-M3 and Cortex-M4.
@@ -1294,11 +1247,10 @@ extern "C"
    * @param[in]  blockSize  number of samples to process.
    */
   void arm_biquad_cascade_df1_fast_q31(
-  const arm_biquad_casd_df1_inst_q31 * S,
-  q31_t * pSrc,
-  q31_t * pDst,
-  uint32_t blockSize);
-
+      const arm_biquad_casd_df1_inst_q31 *S,
+      q31_t *pSrc,
+      q31_t *pDst,
+      uint32_t blockSize);
 
   /**
    * @brief  Initialization function for the Q31 Biquad cascade filter.
@@ -1309,12 +1261,11 @@ extern "C"
    * @param[in]     postShift  Shift to be applied to the output. Varies according to the coefficients format
    */
   void arm_biquad_cascade_df1_init_q31(
-  arm_biquad_casd_df1_inst_q31 * S,
-  uint8_t numStages,
-  q31_t * pCoeffs,
-  q31_t * pState,
-  int8_t postShift);
-
+      arm_biquad_casd_df1_inst_q31 *S,
+      uint8_t numStages,
+      q31_t *pCoeffs,
+      q31_t *pState,
+      int8_t postShift);
 
   /**
    * @brief Processing function for the floating-point Biquad cascade filter.
@@ -1324,11 +1275,10 @@ extern "C"
    * @param[in]  blockSize  number of samples to process.
    */
   void arm_biquad_cascade_df1_f32(
-  const arm_biquad_casd_df1_inst_f32 * S,
-  float32_t * pSrc,
-  float32_t * pDst,
-  uint32_t blockSize);
-
+      const arm_biquad_casd_df1_inst_f32 *S,
+      float32_t *pSrc,
+      float32_t *pDst,
+      uint32_t blockSize);
 
   /**
    * @brief  Initialization function for the floating-point Biquad cascade filter.
@@ -1338,31 +1288,29 @@ extern "C"
    * @param[in]     pState     points to the state buffer.
    */
   void arm_biquad_cascade_df1_init_f32(
-  arm_biquad_casd_df1_inst_f32 * S,
-  uint8_t numStages,
-  float32_t * pCoeffs,
-  float32_t * pState);
-
+      arm_biquad_casd_df1_inst_f32 *S,
+      uint8_t numStages,
+      float32_t *pCoeffs,
+      float32_t *pState);
 
   /**
    * @brief Instance structure for the floating-point matrix structure.
    */
   typedef struct
   {
-    uint16_t numRows;     /**< number of rows of the matrix.     */
-    uint16_t numCols;     /**< number of columns of the matrix.  */
-    float32_t *pData;     /**< points to the data of the matrix. */
+    uint16_t numRows; /**< number of rows of the matrix.     */
+    uint16_t numCols; /**< number of columns of the matrix.  */
+    float32_t *pData; /**< points to the data of the matrix. */
   } arm_matrix_instance_f32;
 
-
   /**
    * @brief Instance structure for the floating-point matrix structure.
    */
   typedef struct
   {
-    uint16_t numRows;     /**< number of rows of the matrix.     */
-    uint16_t numCols;     /**< number of columns of the matrix.  */
-    float64_t *pData;     /**< points to the data of the matrix. */
+    uint16_t numRows; /**< number of rows of the matrix.     */
+    uint16_t numCols; /**< number of columns of the matrix.  */
+    float64_t *pData; /**< points to the data of the matrix. */
   } arm_matrix_instance_f64;
 
   /**
@@ -1370,9 +1318,9 @@ extern "C"
    */
   typedef struct
   {
-    uint16_t numRows;     /**< number of rows of the matrix.     */
-    uint16_t numCols;     /**< number of columns of the matrix.  */
-    q15_t *pData;         /**< points to the data of the matrix. */
+    uint16_t numRows; /**< number of rows of the matrix.     */
+    uint16_t numCols; /**< number of columns of the matrix.  */
+    q15_t *pData;     /**< points to the data of the matrix. */
   } arm_matrix_instance_q15;
 
   /**
@@ -1380,11 +1328,10 @@ extern "C"
    */
   typedef struct
   {
-    uint16_t numRows;     /**< number of rows of the matrix.     */
-    uint16_t numCols;     /**< number of columns of the matrix.  */
-    q31_t *pData;         /**< points to the data of the matrix. */
+    uint16_t numRows; /**< number of rows of the matrix.     */
+    uint16_t numCols; /**< number of columns of the matrix.  */
+    q31_t *pData;     /**< points to the data of the matrix. */
   } arm_matrix_instance_q31;
-
 
   /**
    * @brief Floating-point matrix addition.
@@ -1395,10 +1342,9 @@ extern "C"
    * <code>ARM_MATH_SIZE_MISMATCH</code> or <code>ARM_MATH_SUCCESS</code> based on the outcome of size checking.
    */
   arm_status arm_mat_add_f32(
-  const arm_matrix_instance_f32 * pSrcA,
-  const arm_matrix_instance_f32 * pSrcB,
-  arm_matrix_instance_f32 * pDst);
-
+      const arm_matrix_instance_f32 *pSrcA,
+      const arm_matrix_instance_f32 *pSrcB,
+      arm_matrix_instance_f32 *pDst);
 
   /**
    * @brief Q15 matrix addition.
@@ -1409,10 +1355,9 @@ extern "C"
    * <code>ARM_MATH_SIZE_MISMATCH</code> or <code>ARM_MATH_SUCCESS</code> based on the outcome of size checking.
    */
   arm_status arm_mat_add_q15(
-  const arm_matrix_instance_q15 * pSrcA,
-  const arm_matrix_instance_q15 * pSrcB,
-  arm_matrix_instance_q15 * pDst);
-
+      const arm_matrix_instance_q15 *pSrcA,
+      const arm_matrix_instance_q15 *pSrcB,
+      arm_matrix_instance_q15 *pDst);
 
   /**
    * @brief Q31 matrix addition.
@@ -1423,10 +1368,9 @@ extern "C"
    * <code>ARM_MATH_SIZE_MISMATCH</code> or <code>ARM_MATH_SUCCESS</code> based on the outcome of size checking.
    */
   arm_status arm_mat_add_q31(
-  const arm_matrix_instance_q31 * pSrcA,
-  const arm_matrix_instance_q31 * pSrcB,
-  arm_matrix_instance_q31 * pDst);
-
+      const arm_matrix_instance_q31 *pSrcA,
+      const arm_matrix_instance_q31 *pSrcB,
+      arm_matrix_instance_q31 *pDst);
 
   /**
    * @brief Floating-point, complex, matrix multiplication.
@@ -1437,10 +1381,9 @@ extern "C"
    * <code>ARM_MATH_SIZE_MISMATCH</code> or <code>ARM_MATH_SUCCESS</code> based on the outcome of size checking.
    */
   arm_status arm_mat_cmplx_mult_f32(
-  const arm_matrix_instance_f32 * pSrcA,
-  const arm_matrix_instance_f32 * pSrcB,
-  arm_matrix_instance_f32 * pDst);
-
+      const arm_matrix_instance_f32 *pSrcA,
+      const arm_matrix_instance_f32 *pSrcB,
+      arm_matrix_instance_f32 *pDst);
 
   /**
    * @brief Q15, complex,  matrix multiplication.
@@ -1451,11 +1394,10 @@ extern "C"
    * <code>ARM_MATH_SIZE_MISMATCH</code> or <code>ARM_MATH_SUCCESS</code> based on the outcome of size checking.
    */
   arm_status arm_mat_cmplx_mult_q15(
-  const arm_matrix_instance_q15 * pSrcA,
-  const arm_matrix_instance_q15 * pSrcB,
-  arm_matrix_instance_q15 * pDst,
-  q15_t * pScratch);
-
+      const arm_matrix_instance_q15 *pSrcA,
+      const arm_matrix_instance_q15 *pSrcB,
+      arm_matrix_instance_q15 *pDst,
+      q15_t *pScratch);
 
   /**
    * @brief Q31, complex, matrix multiplication.
@@ -1466,10 +1408,9 @@ extern "C"
    * <code>ARM_MATH_SIZE_MISMATCH</code> or <code>ARM_MATH_SUCCESS</code> based on the outcome of size checking.
    */
   arm_status arm_mat_cmplx_mult_q31(
-  const arm_matrix_instance_q31 * pSrcA,
-  const arm_matrix_instance_q31 * pSrcB,
-  arm_matrix_instance_q31 * pDst);
-
+      const arm_matrix_instance_q31 *pSrcA,
+      const arm_matrix_instance_q31 *pSrcB,
+      arm_matrix_instance_q31 *pDst);
 
   /**
    * @brief Floating-point matrix transpose.
@@ -1479,9 +1420,8 @@ extern "C"
    * or <code>ARM_MATH_SUCCESS</code> based on the outcome of size checking.
    */
   arm_status arm_mat_trans_f32(
-  const arm_matrix_instance_f32 * pSrc,
-  arm_matrix_instance_f32 * pDst);
-
+      const arm_matrix_instance_f32 *pSrc,
+      arm_matrix_instance_f32 *pDst);
 
   /**
    * @brief Q15 matrix transpose.
@@ -1491,9 +1431,8 @@ extern "C"
    * or <code>ARM_MATH_SUCCESS</code> based on the outcome of size checking.
    */
   arm_status arm_mat_trans_q15(
-  const arm_matrix_instance_q15 * pSrc,
-  arm_matrix_instance_q15 * pDst);
-
+      const arm_matrix_instance_q15 *pSrc,
+      arm_matrix_instance_q15 *pDst);
 
   /**
    * @brief Q31 matrix transpose.
@@ -1503,9 +1442,8 @@ extern "C"
    * or <code>ARM_MATH_SUCCESS</code> based on the outcome of size checking.
    */
   arm_status arm_mat_trans_q31(
-  const arm_matrix_instance_q31 * pSrc,
-  arm_matrix_instance_q31 * pDst);
-
+      const arm_matrix_instance_q31 *pSrc,
+      arm_matrix_instance_q31 *pDst);
 
   /**
    * @brief Floating-point matrix multiplication
@@ -1516,10 +1454,9 @@ extern "C"
    * <code>ARM_MATH_SIZE_MISMATCH</code> or <code>ARM_MATH_SUCCESS</code> based on the outcome of size checking.
    */
   arm_status arm_mat_mult_f32(
-  const arm_matrix_instance_f32 * pSrcA,
-  const arm_matrix_instance_f32 * pSrcB,
-  arm_matrix_instance_f32 * pDst);
-
+      const arm_matrix_instance_f32 *pSrcA,
+      const arm_matrix_instance_f32 *pSrcB,
+      arm_matrix_instance_f32 *pDst);
 
   /**
    * @brief Q15 matrix multiplication
@@ -1531,11 +1468,10 @@ extern "C"
    * <code>ARM_MATH_SIZE_MISMATCH</code> or <code>ARM_MATH_SUCCESS</code> based on the outcome of size checking.
    */
   arm_status arm_mat_mult_q15(
-  const arm_matrix_instance_q15 * pSrcA,
-  const arm_matrix_instance_q15 * pSrcB,
-  arm_matrix_instance_q15 * pDst,
-  q15_t * pState);
-
+      const arm_matrix_instance_q15 *pSrcA,
+      const arm_matrix_instance_q15 *pSrcB,
+      arm_matrix_instance_q15 *pDst,
+      q15_t *pState);
 
   /**
    * @brief Q15 matrix multiplication (fast variant) for Cortex-M3 and Cortex-M4
@@ -1547,11 +1483,10 @@ extern "C"
    * <code>ARM_MATH_SIZE_MISMATCH</code> or <code>ARM_MATH_SUCCESS</code> based on the outcome of size checking.
    */
   arm_status arm_mat_mult_fast_q15(
-  const arm_matrix_instance_q15 * pSrcA,
-  const arm_matrix_instance_q15 * pSrcB,
-  arm_matrix_instance_q15 * pDst,
-  q15_t * pState);
-
+      const arm_matrix_instance_q15 *pSrcA,
+      const arm_matrix_instance_q15 *pSrcB,
+      arm_matrix_instance_q15 *pDst,
+      q15_t *pState);
 
   /**
    * @brief Q31 matrix multiplication
@@ -1562,10 +1497,9 @@ extern "C"
    * <code>ARM_MATH_SIZE_MISMATCH</code> or <code>ARM_MATH_SUCCESS</code> based on the outcome of size checking.
    */
   arm_status arm_mat_mult_q31(
-  const arm_matrix_instance_q31 * pSrcA,
-  const arm_matrix_instance_q31 * pSrcB,
-  arm_matrix_instance_q31 * pDst);
-
+      const arm_matrix_instance_q31 *pSrcA,
+      const arm_matrix_instance_q31 *pSrcB,
+      arm_matrix_instance_q31 *pDst);
 
   /**
    * @brief Q31 matrix multiplication (fast variant) for Cortex-M3 and Cortex-M4
@@ -1576,10 +1510,9 @@ extern "C"
    * <code>ARM_MATH_SIZE_MISMATCH</code> or <code>ARM_MATH_SUCCESS</code> based on the outcome of size checking.
    */
   arm_status arm_mat_mult_fast_q31(
-  const arm_matrix_instance_q31 * pSrcA,
-  const arm_matrix_instance_q31 * pSrcB,
-  arm_matrix_instance_q31 * pDst);
-
+      const arm_matrix_instance_q31 *pSrcA,
+      const arm_matrix_instance_q31 *pSrcB,
+      arm_matrix_instance_q31 *pDst);
 
   /**
    * @brief Floating-point matrix subtraction
@@ -1590,10 +1523,9 @@ extern "C"
    * <code>ARM_MATH_SIZE_MISMATCH</code> or <code>ARM_MATH_SUCCESS</code> based on the outcome of size checking.
    */
   arm_status arm_mat_sub_f32(
-  const arm_matrix_instance_f32 * pSrcA,
-  const arm_matrix_instance_f32 * pSrcB,
-  arm_matrix_instance_f32 * pDst);
-
+      const arm_matrix_instance_f32 *pSrcA,
+      const arm_matrix_instance_f32 *pSrcB,
+      arm_matrix_instance_f32 *pDst);
 
   /**
    * @brief Q15 matrix subtraction
@@ -1604,10 +1536,9 @@ extern "C"
    * <code>ARM_MATH_SIZE_MISMATCH</code> or <code>ARM_MATH_SUCCESS</code> based on the outcome of size checking.
    */
   arm_status arm_mat_sub_q15(
-  const arm_matrix_instance_q15 * pSrcA,
-  const arm_matrix_instance_q15 * pSrcB,
-  arm_matrix_instance_q15 * pDst);
-
+      const arm_matrix_instance_q15 *pSrcA,
+      const arm_matrix_instance_q15 *pSrcB,
+      arm_matrix_instance_q15 *pDst);
 
   /**
    * @brief Q31 matrix subtraction
@@ -1618,10 +1549,9 @@ extern "C"
    * <code>ARM_MATH_SIZE_MISMATCH</code> or <code>ARM_MATH_SUCCESS</code> based on the outcome of size checking.
    */
   arm_status arm_mat_sub_q31(
-  const arm_matrix_instance_q31 * pSrcA,
-  const arm_matrix_instance_q31 * pSrcB,
-  arm_matrix_instance_q31 * pDst);
-
+      const arm_matrix_instance_q31 *pSrcA,
+      const arm_matrix_instance_q31 *pSrcB,
+      arm_matrix_instance_q31 *pDst);
 
   /**
    * @brief Floating-point matrix scaling.
@@ -1632,10 +1562,9 @@ extern "C"
    * <code>ARM_MATH_SIZE_MISMATCH</code> or <code>ARM_MATH_SUCCESS</code> based on the outcome of size checking.
    */
   arm_status arm_mat_scale_f32(
-  const arm_matrix_instance_f32 * pSrc,
-  float32_t scale,
-  arm_matrix_instance_f32 * pDst);
-
+      const arm_matrix_instance_f32 *pSrc,
+      float32_t scale,
+      arm_matrix_instance_f32 *pDst);
 
   /**
    * @brief Q15 matrix scaling.
@@ -1647,11 +1576,10 @@ extern "C"
    * <code>ARM_MATH_SIZE_MISMATCH</code> or <code>ARM_MATH_SUCCESS</code> based on the outcome of size checking.
    */
   arm_status arm_mat_scale_q15(
-  const arm_matrix_instance_q15 * pSrc,
-  q15_t scaleFract,
-  int32_t shift,
-  arm_matrix_instance_q15 * pDst);
-
+      const arm_matrix_instance_q15 *pSrc,
+      q15_t scaleFract,
+      int32_t shift,
+      arm_matrix_instance_q15 *pDst);
 
   /**
    * @brief Q31 matrix scaling.
@@ -1663,11 +1591,10 @@ extern "C"
    * <code>ARM_MATH_SIZE_MISMATCH</code> or <code>ARM_MATH_SUCCESS</code> based on the outcome of size checking.
    */
   arm_status arm_mat_scale_q31(
-  const arm_matrix_instance_q31 * pSrc,
-  q31_t scaleFract,
-  int32_t shift,
-  arm_matrix_instance_q31 * pDst);
-
+      const arm_matrix_instance_q31 *pSrc,
+      q31_t scaleFract,
+      int32_t shift,
+      arm_matrix_instance_q31 *pDst);
 
   /**
    * @brief  Q31 matrix initialization.
@@ -1677,11 +1604,10 @@ extern "C"
    * @param[in]     pData     points to the matrix data array.
    */
   void arm_mat_init_q31(
-  arm_matrix_instance_q31 * S,
-  uint16_t nRows,
-  uint16_t nColumns,
-  q31_t * pData);
-
+      arm_matrix_instance_q31 *S,
+      uint16_t nRows,
+      uint16_t nColumns,
+      q31_t *pData);
 
   /**
    * @brief  Q15 matrix initialization.
@@ -1691,11 +1617,10 @@ extern "C"
    * @param[in]     pData     points to the matrix data array.
    */
   void arm_mat_init_q15(
-  arm_matrix_instance_q15 * S,
-  uint16_t nRows,
-  uint16_t nColumns,
-  q15_t * pData);
-
+      arm_matrix_instance_q15 *S,
+      uint16_t nRows,
+      uint16_t nColumns,
+      q15_t *pData);
 
   /**
    * @brief  Floating-point matrix initialization.
@@ -1705,29 +1630,27 @@ extern "C"
    * @param[in]     pData     points to the matrix data array.
    */
   void arm_mat_init_f32(
-  arm_matrix_instance_f32 * S,
-  uint16_t nRows,
-  uint16_t nColumns,
-  float32_t * pData);
-
-
+      arm_matrix_instance_f32 *S,
+      uint16_t nRows,
+      uint16_t nColumns,
+      float32_t *pData);
 
   /**
    * @brief Instance structure for the Q15 PID Control.
    */
   typedef struct
   {
-    q15_t A0;           /**< The derived gain, A0 = Kp + Ki + Kd . */
-#if !defined (ARM_MATH_DSP)
+    q15_t A0; /**< The derived gain, A0 = Kp + Ki + Kd . */
+#if !defined(ARM_MATH_DSP)
     q15_t A1;
     q15_t A2;
 #else
-    q31_t A1;           /**< The derived gain A1 = -Kp - 2Kd | Kd.*/
+  q31_t A1; /**< The derived gain A1 = -Kp - 2Kd | Kd.*/
 #endif
-    q15_t state[3];     /**< The state array of length 3. */
-    q15_t Kp;           /**< The proportional gain. */
-    q15_t Ki;           /**< The integral gain. */
-    q15_t Kd;           /**< The derivative gain. */
+    q15_t state[3]; /**< The state array of length 3. */
+    q15_t Kp;       /**< The proportional gain. */
+    q15_t Ki;       /**< The integral gain. */
+    q15_t Kd;       /**< The derivative gain. */
   } arm_pid_instance_q15;
 
   /**
@@ -1735,13 +1658,13 @@ extern "C"
    */
   typedef struct
   {
-    q31_t A0;            /**< The derived gain, A0 = Kp + Ki + Kd . */
-    q31_t A1;            /**< The derived gain, A1 = -Kp - 2Kd. */
-    q31_t A2;            /**< The derived gain, A2 = Kd . */
-    q31_t state[3];      /**< The state array of length 3. */
-    q31_t Kp;            /**< The proportional gain. */
-    q31_t Ki;            /**< The integral gain. */
-    q31_t Kd;            /**< The derivative gain. */
+    q31_t A0;       /**< The derived gain, A0 = Kp + Ki + Kd . */
+    q31_t A1;       /**< The derived gain, A1 = -Kp - 2Kd. */
+    q31_t A2;       /**< The derived gain, A2 = Kd . */
+    q31_t state[3]; /**< The state array of length 3. */
+    q31_t Kp;       /**< The proportional gain. */
+    q31_t Ki;       /**< The integral gain. */
+    q31_t Kd;       /**< The derivative gain. */
   } arm_pid_instance_q31;
 
   /**
@@ -1749,16 +1672,14 @@ extern "C"
    */
   typedef struct
   {
-    float32_t A0;          /**< The derived gain, A0 = Kp + Ki + Kd . */
-    float32_t A1;          /**< The derived gain, A1 = -Kp - 2Kd. */
-    float32_t A2;          /**< The derived gain, A2 = Kd . */
-    float32_t state[3];    /**< The state array of length 3. */
-    float32_t Kp;          /**< The proportional gain. */
-    float32_t Ki;          /**< The integral gain. */
-    float32_t Kd;          /**< The derivative gain. */
+    float32_t A0;       /**< The derived gain, A0 = Kp + Ki + Kd . */
+    float32_t A1;       /**< The derived gain, A1 = -Kp - 2Kd. */
+    float32_t A2;       /**< The derived gain, A2 = Kd . */
+    float32_t state[3]; /**< The state array of length 3. */
+    float32_t Kp;       /**< The proportional gain. */
+    float32_t Ki;       /**< The integral gain. */
+    float32_t Kd;       /**< The derivative gain. */
   } arm_pid_instance_f32;
-
-
 
   /**
    * @brief  Initialization function for the floating-point PID Control.
@@ -1766,17 +1687,15 @@ extern "C"
    * @param[in]     resetStateFlag  flag to reset the state. 0 = no change in state 1 = reset the state.
    */
   void arm_pid_init_f32(
-  arm_pid_instance_f32 * S,
-  int32_t resetStateFlag);
-
+      arm_pid_instance_f32 *S,
+      int32_t resetStateFlag);
 
   /**
    * @brief  Reset function for the floating-point PID Control.
    * @param[in,out] S  is an instance of the floating-point PID Control structure
    */
   void arm_pid_reset_f32(
-  arm_pid_instance_f32 * S);
-
+      arm_pid_instance_f32 *S);
 
   /**
    * @brief  Initialization function for the Q31 PID Control.
@@ -1784,9 +1703,8 @@ extern "C"
    * @param[in]     resetStateFlag  flag to reset the state. 0 = no change in state 1 = reset the state.
    */
   void arm_pid_init_q31(
-  arm_pid_instance_q31 * S,
-  int32_t resetStateFlag);
-
+      arm_pid_instance_q31 *S,
+      int32_t resetStateFlag);
 
   /**
    * @brief  Reset function for the Q31 PID Control.
@@ -1794,8 +1712,7 @@ extern "C"
    */
 
   void arm_pid_reset_q31(
-  arm_pid_instance_q31 * S);
-
+      arm_pid_instance_q31 *S);
 
   /**
    * @brief  Initialization function for the Q15 PID Control.
@@ -1803,27 +1720,25 @@ extern "C"
    * @param[in]     resetStateFlag  flag to reset the state. 0 = no change in state 1 = reset the state.
    */
   void arm_pid_init_q15(
-  arm_pid_instance_q15 * S,
-  int32_t resetStateFlag);
-
+      arm_pid_instance_q15 *S,
+      int32_t resetStateFlag);
 
   /**
    * @brief  Reset function for the Q15 PID Control.
    * @param[in,out] S  points to an instance of the q15 PID Control structure
    */
   void arm_pid_reset_q15(
-  arm_pid_instance_q15 * S);
-
+      arm_pid_instance_q15 *S);
 
   /**
    * @brief Instance structure for the floating-point Linear Interpolate function.
    */
   typedef struct
   {
-    uint32_t nValues;           /**< nValues */
-    float32_t x1;               /**< x1 */
-    float32_t xSpacing;         /**< xSpacing */
-    float32_t *pYData;          /**< pointer to the table of Y values */
+    uint32_t nValues;   /**< nValues */
+    float32_t x1;       /**< x1 */
+    float32_t xSpacing; /**< xSpacing */
+    float32_t *pYData;  /**< pointer to the table of Y values */
   } arm_linear_interp_instance_f32;
 
   /**
@@ -1831,41 +1746,40 @@ extern "C"
    */
   typedef struct
   {
-    uint16_t numRows;   /**< number of rows in the data table. */
-    uint16_t numCols;   /**< number of columns in the data table. */
-    float32_t *pData;   /**< points to the data table. */
+    uint16_t numRows; /**< number of rows in the data table. */
+    uint16_t numCols; /**< number of columns in the data table. */
+    float32_t *pData; /**< points to the data table. */
   } arm_bilinear_interp_instance_f32;
 
-   /**
+  /**
    * @brief Instance structure for the Q31 bilinear interpolation function.
    */
   typedef struct
   {
-    uint16_t numRows;   /**< number of rows in the data table. */
-    uint16_t numCols;   /**< number of columns in the data table. */
-    q31_t *pData;       /**< points to the data table. */
+    uint16_t numRows; /**< number of rows in the data table. */
+    uint16_t numCols; /**< number of columns in the data table. */
+    q31_t *pData;     /**< points to the data table. */
   } arm_bilinear_interp_instance_q31;
 
-   /**
+  /**
    * @brief Instance structure for the Q15 bilinear interpolation function.
    */
   typedef struct
   {
-    uint16_t numRows;   /**< number of rows in the data table. */
-    uint16_t numCols;   /**< number of columns in the data table. */
-    q15_t *pData;       /**< points to the data table. */
+    uint16_t numRows; /**< number of rows in the data table. */
+    uint16_t numCols; /**< number of columns in the data table. */
+    q15_t *pData;     /**< points to the data table. */
   } arm_bilinear_interp_instance_q15;
 
-   /**
+  /**
    * @brief Instance structure for the Q15 bilinear interpolation function.
    */
   typedef struct
   {
-    uint16_t numRows;   /**< number of rows in the data table. */
-    uint16_t numCols;   /**< number of columns in the data table. */
-    q7_t *pData;        /**< points to the data table. */
+    uint16_t numRows; /**< number of rows in the data table. */
+    uint16_t numCols; /**< number of columns in the data table. */
+    q7_t *pData;      /**< points to the data table. */
   } arm_bilinear_interp_instance_q7;
-
 
   /**
    * @brief Q7 vector multiplication.
@@ -1875,11 +1789,10 @@ extern "C"
    * @param[in]  blockSize  number of samples in each vector
    */
   void arm_mult_q7(
-  q7_t * pSrcA,
-  q7_t * pSrcB,
-  q7_t * pDst,
-  uint32_t blockSize);
-
+      q7_t *pSrcA,
+      q7_t *pSrcB,
+      q7_t *pDst,
+      uint32_t blockSize);
 
   /**
    * @brief Q15 vector multiplication.
@@ -1889,11 +1802,10 @@ extern "C"
    * @param[in]  blockSize  number of samples in each vector
    */
   void arm_mult_q15(
-  q15_t * pSrcA,
-  q15_t * pSrcB,
-  q15_t * pDst,
-  uint32_t blockSize);
-
+      q15_t *pSrcA,
+      q15_t *pSrcB,
+      q15_t *pDst,
+      uint32_t blockSize);
 
   /**
    * @brief Q31 vector multiplication.
@@ -1903,11 +1815,10 @@ extern "C"
    * @param[in]  blockSize  number of samples in each vector
    */
   void arm_mult_q31(
-  q31_t * pSrcA,
-  q31_t * pSrcB,
-  q31_t * pDst,
-  uint32_t blockSize);
-
+      q31_t *pSrcA,
+      q31_t *pSrcB,
+      q31_t *pDst,
+      uint32_t blockSize);
 
   /**
    * @brief Floating-point vector multiplication.
@@ -1917,317 +1828,315 @@ extern "C"
    * @param[in]  blockSize  number of samples in each vector
    */
   void arm_mult_f32(
-  float32_t * pSrcA,
-  float32_t * pSrcB,
-  float32_t * pDst,
-  uint32_t blockSize);
-
+      float32_t *pSrcA,
+      float32_t *pSrcB,
+      float32_t *pDst,
+      uint32_t blockSize);
 
   /**
    * @brief Instance structure for the Q15 CFFT/CIFFT function.
    */
   typedef struct
   {
-    uint16_t fftLen;                 /**< length of the FFT. */
-    uint8_t ifftFlag;                /**< flag that selects forward (ifftFlag=0) or inverse (ifftFlag=1) transform. */
-    uint8_t bitReverseFlag;          /**< flag that enables (bitReverseFlag=1) or disables (bitReverseFlag=0) bit reversal of output. */
-    q15_t *pTwiddle;                 /**< points to the Sin twiddle factor table. */
-    uint16_t *pBitRevTable;          /**< points to the bit reversal table. */
-    uint16_t twidCoefModifier;       /**< twiddle coefficient modifier that supports different size FFTs with the same twiddle factor table. */
-    uint16_t bitRevFactor;           /**< bit reversal modifier that supports different size FFTs with the same bit reversal table. */
+    uint16_t fftLen;           /**< length of the FFT. */
+    uint8_t ifftFlag;          /**< flag that selects forward (ifftFlag=0) or inverse (ifftFlag=1) transform. */
+    uint8_t bitReverseFlag;    /**< flag that enables (bitReverseFlag=1) or disables (bitReverseFlag=0) bit reversal of output. */
+    q15_t *pTwiddle;           /**< points to the Sin twiddle factor table. */
+    uint16_t *pBitRevTable;    /**< points to the bit reversal table. */
+    uint16_t twidCoefModifier; /**< twiddle coefficient modifier that supports different size FFTs with the same twiddle factor table. */
+    uint16_t bitRevFactor;     /**< bit reversal modifier that supports different size FFTs with the same bit reversal table. */
   } arm_cfft_radix2_instance_q15;
 
-/* Deprecated */
+  /* Deprecated */
   arm_status arm_cfft_radix2_init_q15(
-  arm_cfft_radix2_instance_q15 * S,
-  uint16_t fftLen,
-  uint8_t ifftFlag,
-  uint8_t bitReverseFlag);
+      arm_cfft_radix2_instance_q15 *S,
+      uint16_t fftLen,
+      uint8_t ifftFlag,
+      uint8_t bitReverseFlag);
 
-/* Deprecated */
+  /* Deprecated */
   void arm_cfft_radix2_q15(
-  const arm_cfft_radix2_instance_q15 * S,
-  q15_t * pSrc);
-
+      const arm_cfft_radix2_instance_q15 *S,
+      q15_t *pSrc);
 
   /**
    * @brief Instance structure for the Q15 CFFT/CIFFT function.
    */
   typedef struct
   {
-    uint16_t fftLen;                 /**< length of the FFT. */
-    uint8_t ifftFlag;                /**< flag that selects forward (ifftFlag=0) or inverse (ifftFlag=1) transform. */
-    uint8_t bitReverseFlag;          /**< flag that enables (bitReverseFlag=1) or disables (bitReverseFlag=0) bit reversal of output. */
-    q15_t *pTwiddle;                 /**< points to the twiddle factor table. */
-    uint16_t *pBitRevTable;          /**< points to the bit reversal table. */
-    uint16_t twidCoefModifier;       /**< twiddle coefficient modifier that supports different size FFTs with the same twiddle factor table. */
-    uint16_t bitRevFactor;           /**< bit reversal modifier that supports different size FFTs with the same bit reversal table. */
+    uint16_t fftLen;           /**< length of the FFT. */
+    uint8_t ifftFlag;          /**< flag that selects forward (ifftFlag=0) or inverse (ifftFlag=1) transform. */
+    uint8_t bitReverseFlag;    /**< flag that enables (bitReverseFlag=1) or disables (bitReverseFlag=0) bit reversal of output. */
+    q15_t *pTwiddle;           /**< points to the twiddle factor table. */
+    uint16_t *pBitRevTable;    /**< points to the bit reversal table. */
+    uint16_t twidCoefModifier; /**< twiddle coefficient modifier that supports different size FFTs with the same twiddle factor table. */
+    uint16_t bitRevFactor;     /**< bit reversal modifier that supports different size FFTs with the same bit reversal table. */
   } arm_cfft_radix4_instance_q15;
 
-/* Deprecated */
+  /* Deprecated */
   arm_status arm_cfft_radix4_init_q15(
-  arm_cfft_radix4_instance_q15 * S,
-  uint16_t fftLen,
-  uint8_t ifftFlag,
-  uint8_t bitReverseFlag);
+      arm_cfft_radix4_instance_q15 *S,
+      uint16_t fftLen,
+      uint8_t ifftFlag,
+      uint8_t bitReverseFlag);
 
-/* Deprecated */
+  /* Deprecated */
   void arm_cfft_radix4_q15(
-  const arm_cfft_radix4_instance_q15 * S,
-  q15_t * pSrc);
+      const arm_cfft_radix4_instance_q15 *S,
+      q15_t *pSrc);
 
   /**
    * @brief Instance structure for the Radix-2 Q31 CFFT/CIFFT function.
    */
   typedef struct
   {
-    uint16_t fftLen;                 /**< length of the FFT. */
-    uint8_t ifftFlag;                /**< flag that selects forward (ifftFlag=0) or inverse (ifftFlag=1) transform. */
-    uint8_t bitReverseFlag;          /**< flag that enables (bitReverseFlag=1) or disables (bitReverseFlag=0) bit reversal of output. */
-    q31_t *pTwiddle;                 /**< points to the Twiddle factor table. */
-    uint16_t *pBitRevTable;          /**< points to the bit reversal table. */
-    uint16_t twidCoefModifier;       /**< twiddle coefficient modifier that supports different size FFTs with the same twiddle factor table. */
-    uint16_t bitRevFactor;           /**< bit reversal modifier that supports different size FFTs with the same bit reversal table. */
+    uint16_t fftLen;           /**< length of the FFT. */
+    uint8_t ifftFlag;          /**< flag that selects forward (ifftFlag=0) or inverse (ifftFlag=1) transform. */
+    uint8_t bitReverseFlag;    /**< flag that enables (bitReverseFlag=1) or disables (bitReverseFlag=0) bit reversal of output. */
+    q31_t *pTwiddle;           /**< points to the Twiddle factor table. */
+    uint16_t *pBitRevTable;    /**< points to the bit reversal table. */
+    uint16_t twidCoefModifier; /**< twiddle coefficient modifier that supports different size FFTs with the same twiddle factor table. */
+    uint16_t bitRevFactor;     /**< bit reversal modifier that supports different size FFTs with the same bit reversal table. */
   } arm_cfft_radix2_instance_q31;
 
-/* Deprecated */
+  /* Deprecated */
   arm_status arm_cfft_radix2_init_q31(
-  arm_cfft_radix2_instance_q31 * S,
-  uint16_t fftLen,
-  uint8_t ifftFlag,
-  uint8_t bitReverseFlag);
+      arm_cfft_radix2_instance_q31 *S,
+      uint16_t fftLen,
+      uint8_t ifftFlag,
+      uint8_t bitReverseFlag);
 
-/* Deprecated */
+  /* Deprecated */
   void arm_cfft_radix2_q31(
-  const arm_cfft_radix2_instance_q31 * S,
-  q31_t * pSrc);
+      const arm_cfft_radix2_instance_q31 *S,
+      q31_t *pSrc);
 
   /**
    * @brief Instance structure for the Q31 CFFT/CIFFT function.
    */
   typedef struct
   {
-    uint16_t fftLen;                 /**< length of the FFT. */
-    uint8_t ifftFlag;                /**< flag that selects forward (ifftFlag=0) or inverse (ifftFlag=1) transform. */
-    uint8_t bitReverseFlag;          /**< flag that enables (bitReverseFlag=1) or disables (bitReverseFlag=0) bit reversal of output. */
-    q31_t *pTwiddle;                 /**< points to the twiddle factor table. */
-    uint16_t *pBitRevTable;          /**< points to the bit reversal table. */
-    uint16_t twidCoefModifier;       /**< twiddle coefficient modifier that supports different size FFTs with the same twiddle factor table. */
-    uint16_t bitRevFactor;           /**< bit reversal modifier that supports different size FFTs with the same bit reversal table. */
+    uint16_t fftLen;           /**< length of the FFT. */
+    uint8_t ifftFlag;          /**< flag that selects forward (ifftFlag=0) or inverse (ifftFlag=1) transform. */
+    uint8_t bitReverseFlag;    /**< flag that enables (bitReverseFlag=1) or disables (bitReverseFlag=0) bit reversal of output. */
+    q31_t *pTwiddle;           /**< points to the twiddle factor table. */
+    uint16_t *pBitRevTable;    /**< points to the bit reversal table. */
+    uint16_t twidCoefModifier; /**< twiddle coefficient modifier that supports different size FFTs with the same twiddle factor table. */
+    uint16_t bitRevFactor;     /**< bit reversal modifier that supports different size FFTs with the same bit reversal table. */
   } arm_cfft_radix4_instance_q31;
 
-/* Deprecated */
+  /* Deprecated */
   void arm_cfft_radix4_q31(
-  const arm_cfft_radix4_instance_q31 * S,
-  q31_t * pSrc);
+      const arm_cfft_radix4_instance_q31 *S,
+      q31_t *pSrc);
 
-/* Deprecated */
+  /* Deprecated */
   arm_status arm_cfft_radix4_init_q31(
-  arm_cfft_radix4_instance_q31 * S,
-  uint16_t fftLen,
-  uint8_t ifftFlag,
-  uint8_t bitReverseFlag);
+      arm_cfft_radix4_instance_q31 *S,
+      uint16_t fftLen,
+      uint8_t ifftFlag,
+      uint8_t bitReverseFlag);
 
   /**
    * @brief Instance structure for the floating-point CFFT/CIFFT function.
    */
   typedef struct
   {
-    uint16_t fftLen;                   /**< length of the FFT. */
-    uint8_t ifftFlag;                  /**< flag that selects forward (ifftFlag=0) or inverse (ifftFlag=1) transform. */
-    uint8_t bitReverseFlag;            /**< flag that enables (bitReverseFlag=1) or disables (bitReverseFlag=0) bit reversal of output. */
-    float32_t *pTwiddle;               /**< points to the Twiddle factor table. */
-    uint16_t *pBitRevTable;            /**< points to the bit reversal table. */
-    uint16_t twidCoefModifier;         /**< twiddle coefficient modifier that supports different size FFTs with the same twiddle factor table. */
-    uint16_t bitRevFactor;             /**< bit reversal modifier that supports different size FFTs with the same bit reversal table. */
-    float32_t onebyfftLen;             /**< value of 1/fftLen. */
+    uint16_t fftLen;           /**< length of the FFT. */
+    uint8_t ifftFlag;          /**< flag that selects forward (ifftFlag=0) or inverse (ifftFlag=1) transform. */
+    uint8_t bitReverseFlag;    /**< flag that enables (bitReverseFlag=1) or disables (bitReverseFlag=0) bit reversal of output. */
+    float32_t *pTwiddle;       /**< points to the Twiddle factor table. */
+    uint16_t *pBitRevTable;    /**< points to the bit reversal table. */
+    uint16_t twidCoefModifier; /**< twiddle coefficient modifier that supports different size FFTs with the same twiddle factor table. */
+    uint16_t bitRevFactor;     /**< bit reversal modifier that supports different size FFTs with the same bit reversal table. */
+    float32_t onebyfftLen;     /**< value of 1/fftLen. */
   } arm_cfft_radix2_instance_f32;
 
-/* Deprecated */
+  /* Deprecated */
   arm_status arm_cfft_radix2_init_f32(
-  arm_cfft_radix2_instance_f32 * S,
-  uint16_t fftLen,
-  uint8_t ifftFlag,
-  uint8_t bitReverseFlag);
+      arm_cfft_radix2_instance_f32 *S,
+      uint16_t fftLen,
+      uint8_t ifftFlag,
+      uint8_t bitReverseFlag);
 
-/* Deprecated */
+  /* Deprecated */
   void arm_cfft_radix2_f32(
-  const arm_cfft_radix2_instance_f32 * S,
-  float32_t * pSrc);
+      const arm_cfft_radix2_instance_f32 *S,
+      float32_t *pSrc);
 
   /**
    * @brief Instance structure for the floating-point CFFT/CIFFT function.
    */
   typedef struct
   {
-    uint16_t fftLen;                   /**< length of the FFT. */
-    uint8_t ifftFlag;                  /**< flag that selects forward (ifftFlag=0) or inverse (ifftFlag=1) transform. */
-    uint8_t bitReverseFlag;            /**< flag that enables (bitReverseFlag=1) or disables (bitReverseFlag=0) bit reversal of output. */
-    float32_t *pTwiddle;               /**< points to the Twiddle factor table. */
-    uint16_t *pBitRevTable;            /**< points to the bit reversal table. */
-    uint16_t twidCoefModifier;         /**< twiddle coefficient modifier that supports different size FFTs with the same twiddle factor table. */
-    uint16_t bitRevFactor;             /**< bit reversal modifier that supports different size FFTs with the same bit reversal table. */
-    float32_t onebyfftLen;             /**< value of 1/fftLen. */
+    uint16_t fftLen;           /**< length of the FFT. */
+    uint8_t ifftFlag;          /**< flag that selects forward (ifftFlag=0) or inverse (ifftFlag=1) transform. */
+    uint8_t bitReverseFlag;    /**< flag that enables (bitReverseFlag=1) or disables (bitReverseFlag=0) bit reversal of output. */
+    float32_t *pTwiddle;       /**< points to the Twiddle factor table. */
+    uint16_t *pBitRevTable;    /**< points to the bit reversal table. */
+    uint16_t twidCoefModifier; /**< twiddle coefficient modifier that supports different size FFTs with the same twiddle factor table. */
+    uint16_t bitRevFactor;     /**< bit reversal modifier that supports different size FFTs with the same bit reversal table. */
+    float32_t onebyfftLen;     /**< value of 1/fftLen. */
   } arm_cfft_radix4_instance_f32;
 
-/* Deprecated */
+  /* Deprecated */
   arm_status arm_cfft_radix4_init_f32(
-  arm_cfft_radix4_instance_f32 * S,
-  uint16_t fftLen,
-  uint8_t ifftFlag,
-  uint8_t bitReverseFlag);
+      arm_cfft_radix4_instance_f32 *S,
+      uint16_t fftLen,
+      uint8_t ifftFlag,
+      uint8_t bitReverseFlag);
 
-/* Deprecated */
+  /* Deprecated */
   void arm_cfft_radix4_f32(
-  const arm_cfft_radix4_instance_f32 * S,
-  float32_t * pSrc);
+      const arm_cfft_radix4_instance_f32 *S,
+      float32_t *pSrc);
 
   /**
    * @brief Instance structure for the fixed-point CFFT/CIFFT function.
    */
   typedef struct
   {
-    uint16_t fftLen;                   /**< length of the FFT. */
-    const q15_t *pTwiddle;             /**< points to the Twiddle factor table. */
-    const uint16_t *pBitRevTable;      /**< points to the bit reversal table. */
-    uint16_t bitRevLength;             /**< bit reversal table length. */
+    uint16_t fftLen;              /**< length of the FFT. */
+    const q15_t *pTwiddle;        /**< points to the Twiddle factor table. */
+    const uint16_t *pBitRevTable; /**< points to the bit reversal table. */
+    uint16_t bitRevLength;        /**< bit reversal table length. */
   } arm_cfft_instance_q15;
 
-void arm_cfft_q15(
-    const arm_cfft_instance_q15 * S,
-    q15_t * p1,
-    uint8_t ifftFlag,
-    uint8_t bitReverseFlag);
+  void arm_cfft_q15(
+      const arm_cfft_instance_q15 *S,
+      q15_t *p1,
+      uint8_t ifftFlag,
+      uint8_t bitReverseFlag);
 
   /**
    * @brief Instance structure for the fixed-point CFFT/CIFFT function.
    */
   typedef struct
   {
-    uint16_t fftLen;                   /**< length of the FFT. */
-    const q31_t *pTwiddle;             /**< points to the Twiddle factor table. */
-    const uint16_t *pBitRevTable;      /**< points to the bit reversal table. */
-    uint16_t bitRevLength;             /**< bit reversal table length. */
+    uint16_t fftLen;              /**< length of the FFT. */
+    const q31_t *pTwiddle;        /**< points to the Twiddle factor table. */
+    const uint16_t *pBitRevTable; /**< points to the bit reversal table. */
+    uint16_t bitRevLength;        /**< bit reversal table length. */
   } arm_cfft_instance_q31;
 
-void arm_cfft_q31(
-    const arm_cfft_instance_q31 * S,
-    q31_t * p1,
-    uint8_t ifftFlag,
-    uint8_t bitReverseFlag);
+  void arm_cfft_q31(
+      const arm_cfft_instance_q31 *S,
+      q31_t *p1,
+      uint8_t ifftFlag,
+      uint8_t bitReverseFlag);
 
   /**
    * @brief Instance structure for the floating-point CFFT/CIFFT function.
    */
   typedef struct
   {
-    uint16_t fftLen;                   /**< length of the FFT. */
-    const float32_t *pTwiddle;         /**< points to the Twiddle factor table. */
-    const uint16_t *pBitRevTable;      /**< points to the bit reversal table. */
-    uint16_t bitRevLength;             /**< bit reversal table length. */
+    uint16_t fftLen;              /**< length of the FFT. */
+    const float32_t *pTwiddle;    /**< points to the Twiddle factor table. */
+    const uint16_t *pBitRevTable; /**< points to the bit reversal table. */
+    uint16_t bitRevLength;        /**< bit reversal table length. */
   } arm_cfft_instance_f32;
 
   void arm_cfft_f32(
-  const arm_cfft_instance_f32 * S,
-  float32_t * p1,
-  uint8_t ifftFlag,
-  uint8_t bitReverseFlag);
+      const arm_cfft_instance_f32 *S,
+      float32_t *p1,
+      uint8_t ifftFlag,
+      uint8_t bitReverseFlag);
 
   /**
    * @brief Instance structure for the Q15 RFFT/RIFFT function.
    */
   typedef struct
   {
-    uint32_t fftLenReal;                      /**< length of the real FFT. */
-    uint8_t ifftFlagR;                        /**< flag that selects forward (ifftFlagR=0) or inverse (ifftFlagR=1) transform. */
-    uint8_t bitReverseFlagR;                  /**< flag that enables (bitReverseFlagR=1) or disables (bitReverseFlagR=0) bit reversal of output. */
-    uint32_t twidCoefRModifier;               /**< twiddle coefficient modifier that supports different size FFTs with the same twiddle factor table. */
-    q15_t *pTwiddleAReal;                     /**< points to the real twiddle factor table. */
-    q15_t *pTwiddleBReal;                     /**< points to the imag twiddle factor table. */
-    const arm_cfft_instance_q15 *pCfft;       /**< points to the complex FFT instance. */
+    uint32_t fftLenReal;                /**< length of the real FFT. */
+    uint8_t ifftFlagR;                  /**< flag that selects forward (ifftFlagR=0) or inverse (ifftFlagR=1) transform. */
+    uint8_t bitReverseFlagR;            /**< flag that enables (bitReverseFlagR=1) or disables (bitReverseFlagR=0) bit reversal of output. */
+    uint32_t twidCoefRModifier;         /**< twiddle coefficient modifier that supports different size FFTs with the same twiddle factor table. */
+    q15_t *pTwiddleAReal;               /**< points to the real twiddle factor table. */
+    q15_t *pTwiddleBReal;               /**< points to the imag twiddle factor table. */
+    const arm_cfft_instance_q15 *pCfft; /**< points to the complex FFT instance. */
   } arm_rfft_instance_q15;
 
   arm_status arm_rfft_init_q15(
-  arm_rfft_instance_q15 * S,
-  uint32_t fftLenReal,
-  uint32_t ifftFlagR,
-  uint32_t bitReverseFlag);
+      arm_rfft_instance_q15 *S,
+      uint32_t fftLenReal,
+      uint32_t ifftFlagR,
+      uint32_t bitReverseFlag);
 
   void arm_rfft_q15(
-  const arm_rfft_instance_q15 * S,
-  q15_t * pSrc,
-  q15_t * pDst);
+      const arm_rfft_instance_q15 *S,
+      q15_t *pSrc,
+      q15_t *pDst);
 
   /**
    * @brief Instance structure for the Q31 RFFT/RIFFT function.
    */
   typedef struct
   {
-    uint32_t fftLenReal;                        /**< length of the real FFT. */
-    uint8_t ifftFlagR;                          /**< flag that selects forward (ifftFlagR=0) or inverse (ifftFlagR=1) transform. */
-    uint8_t bitReverseFlagR;                    /**< flag that enables (bitReverseFlagR=1) or disables (bitReverseFlagR=0) bit reversal of output. */
-    uint32_t twidCoefRModifier;                 /**< twiddle coefficient modifier that supports different size FFTs with the same twiddle factor table. */
-    q31_t *pTwiddleAReal;                       /**< points to the real twiddle factor table. */
-    q31_t *pTwiddleBReal;                       /**< points to the imag twiddle factor table. */
-    const arm_cfft_instance_q31 *pCfft;         /**< points to the complex FFT instance. */
+    uint32_t fftLenReal;                /**< length of the real FFT. */
+    uint8_t ifftFlagR;                  /**< flag that selects forward (ifftFlagR=0) or inverse (ifftFlagR=1) transform. */
+    uint8_t bitReverseFlagR;            /**< flag that enables (bitReverseFlagR=1) or disables (bitReverseFlagR=0) bit reversal of output. */
+    uint32_t twidCoefRModifier;         /**< twiddle coefficient modifier that supports different size FFTs with the same twiddle factor table. */
+    q31_t *pTwiddleAReal;               /**< points to the real twiddle factor table. */
+    q31_t *pTwiddleBReal;               /**< points to the imag twiddle factor table. */
+    const arm_cfft_instance_q31 *pCfft; /**< points to the complex FFT instance. */
   } arm_rfft_instance_q31;
 
   arm_status arm_rfft_init_q31(
-  arm_rfft_instance_q31 * S,
-  uint32_t fftLenReal,
-  uint32_t ifftFlagR,
-  uint32_t bitReverseFlag);
+      arm_rfft_instance_q31 *S,
+      uint32_t fftLenReal,
+      uint32_t ifftFlagR,
+      uint32_t bitReverseFlag);
 
   void arm_rfft_q31(
-  const arm_rfft_instance_q31 * S,
-  q31_t * pSrc,
-  q31_t * pDst);
+      const arm_rfft_instance_q31 *S,
+      q31_t *pSrc,
+      q31_t *pDst);
 
   /**
    * @brief Instance structure for the floating-point RFFT/RIFFT function.
    */
   typedef struct
   {
-    uint32_t fftLenReal;                        /**< length of the real FFT. */
-    uint16_t fftLenBy2;                         /**< length of the complex FFT. */
-    uint8_t ifftFlagR;                          /**< flag that selects forward (ifftFlagR=0) or inverse (ifftFlagR=1) transform. */
-    uint8_t bitReverseFlagR;                    /**< flag that enables (bitReverseFlagR=1) or disables (bitReverseFlagR=0) bit reversal of output. */
-    uint32_t twidCoefRModifier;                     /**< twiddle coefficient modifier that supports different size FFTs with the same twiddle factor table. */
-    float32_t *pTwiddleAReal;                   /**< points to the real twiddle factor table. */
-    float32_t *pTwiddleBReal;                   /**< points to the imag twiddle factor table. */
-    arm_cfft_radix4_instance_f32 *pCfft;        /**< points to the complex FFT instance. */
+    uint32_t fftLenReal;                 /**< length of the real FFT. */
+    uint16_t fftLenBy2;                  /**< length of the complex FFT. */
+    uint8_t ifftFlagR;                   /**< flag that selects forward (ifftFlagR=0) or inverse (ifftFlagR=1) transform. */
+    uint8_t bitReverseFlagR;             /**< flag that enables (bitReverseFlagR=1) or disables (bitReverseFlagR=0) bit reversal of output. */
+    uint32_t twidCoefRModifier;          /**< twiddle coefficient modifier that supports different size FFTs with the same twiddle factor table. */
+    float32_t *pTwiddleAReal;            /**< points to the real twiddle factor table. */
+    float32_t *pTwiddleBReal;            /**< points to the imag twiddle factor table. */
+    arm_cfft_radix4_instance_f32 *pCfft; /**< points to the complex FFT instance. */
   } arm_rfft_instance_f32;
 
   arm_status arm_rfft_init_f32(
-  arm_rfft_instance_f32 * S,
-  arm_cfft_radix4_instance_f32 * S_CFFT,
-  uint32_t fftLenReal,
-  uint32_t ifftFlagR,
-  uint32_t bitReverseFlag);
+      arm_rfft_instance_f32 *S,
+      arm_cfft_radix4_instance_f32 *S_CFFT,
+      uint32_t fftLenReal,
+      uint32_t ifftFlagR,
+      uint32_t bitReverseFlag);
 
   void arm_rfft_f32(
-  const arm_rfft_instance_f32 * S,
-  float32_t * pSrc,
-  float32_t * pDst);
+      const arm_rfft_instance_f32 *S,
+      float32_t *pSrc,
+      float32_t *pDst);
 
   /**
    * @brief Instance structure for the floating-point RFFT/RIFFT function.
    */
-typedef struct
+  typedef struct
   {
-    arm_cfft_instance_f32 Sint;      /**< Internal CFFT structure. */
-    uint16_t fftLenRFFT;             /**< length of the real sequence */
-    float32_t * pTwiddleRFFT;        /**< Twiddle factors real stage  */
-  } arm_rfft_fast_instance_f32 ;
+    arm_cfft_instance_f32 Sint; /**< Internal CFFT structure. */
+    uint16_t fftLenRFFT;        /**< length of the real sequence */
+    float32_t *pTwiddleRFFT;    /**< Twiddle factors real stage  */
+  } arm_rfft_fast_instance_f32;
 
-arm_status arm_rfft_fast_init_f32 (
-   arm_rfft_fast_instance_f32 * S,
-   uint16_t fftLen);
+  arm_status arm_rfft_fast_init_f32(
+      arm_rfft_fast_instance_f32 *S,
+      uint16_t fftLen);
 
-void arm_rfft_fast_f32(
-  arm_rfft_fast_instance_f32 * S,
-  float32_t * p, float32_t * pOut,
-  uint8_t ifftFlag);
+  void arm_rfft_fast_f32(
+      arm_rfft_fast_instance_f32 *S,
+      float32_t *p, float32_t *pOut,
+      uint8_t ifftFlag);
 
   /**
    * @brief Instance structure for the floating-point DCT4/IDCT4 function.
@@ -2243,7 +2152,6 @@ void arm_rfft_fast_f32(
     arm_cfft_radix4_instance_f32 *pCfft; /**< points to the complex FFT instance. */
   } arm_dct4_instance_f32;
 
-
   /**
    * @brief  Initialization function for the floating-point DCT4/IDCT4.
    * @param[in,out] S          points to an instance of floating-point DCT4/IDCT4 structure.
@@ -2255,13 +2163,12 @@ void arm_rfft_fast_f32(
    * @return      arm_status function returns ARM_MATH_SUCCESS if initialization is successful or ARM_MATH_ARGUMENT_ERROR if <code>fftLenReal</code> is not a supported transform length.
    */
   arm_status arm_dct4_init_f32(
-  arm_dct4_instance_f32 * S,
-  arm_rfft_instance_f32 * S_RFFT,
-  arm_cfft_radix4_instance_f32 * S_CFFT,
-  uint16_t N,
-  uint16_t Nby2,
-  float32_t normalize);
-
+      arm_dct4_instance_f32 *S,
+      arm_rfft_instance_f32 *S_RFFT,
+      arm_cfft_radix4_instance_f32 *S_CFFT,
+      uint16_t N,
+      uint16_t Nby2,
+      float32_t normalize);
 
   /**
    * @brief Processing function for the floating-point DCT4/IDCT4.
@@ -2270,10 +2177,9 @@ void arm_rfft_fast_f32(
    * @param[in,out] pInlineBuffer  points to the in-place input and output buffer.
    */
   void arm_dct4_f32(
-  const arm_dct4_instance_f32 * S,
-  float32_t * pState,
-  float32_t * pInlineBuffer);
-
+      const arm_dct4_instance_f32 *S,
+      float32_t *pState,
+      float32_t *pInlineBuffer);
 
   /**
    * @brief Instance structure for the Q31 DCT4/IDCT4 function.
@@ -2289,7 +2195,6 @@ void arm_rfft_fast_f32(
     arm_cfft_radix4_instance_q31 *pCfft; /**< points to the complex FFT instance. */
   } arm_dct4_instance_q31;
 
-
   /**
    * @brief  Initialization function for the Q31 DCT4/IDCT4.
    * @param[in,out] S          points to an instance of Q31 DCT4/IDCT4 structure.
@@ -2301,13 +2206,12 @@ void arm_rfft_fast_f32(
    * @return      arm_status function returns ARM_MATH_SUCCESS if initialization is successful or ARM_MATH_ARGUMENT_ERROR if <code>N</code> is not a supported transform length.
    */
   arm_status arm_dct4_init_q31(
-  arm_dct4_instance_q31 * S,
-  arm_rfft_instance_q31 * S_RFFT,
-  arm_cfft_radix4_instance_q31 * S_CFFT,
-  uint16_t N,
-  uint16_t Nby2,
-  q31_t normalize);
-
+      arm_dct4_instance_q31 *S,
+      arm_rfft_instance_q31 *S_RFFT,
+      arm_cfft_radix4_instance_q31 *S_CFFT,
+      uint16_t N,
+      uint16_t Nby2,
+      q31_t normalize);
 
   /**
    * @brief Processing function for the Q31 DCT4/IDCT4.
@@ -2316,10 +2220,9 @@ void arm_rfft_fast_f32(
    * @param[in,out] pInlineBuffer  points to the in-place input and output buffer.
    */
   void arm_dct4_q31(
-  const arm_dct4_instance_q31 * S,
-  q31_t * pState,
-  q31_t * pInlineBuffer);
-
+      const arm_dct4_instance_q31 *S,
+      q31_t *pState,
+      q31_t *pInlineBuffer);
 
   /**
    * @brief Instance structure for the Q15 DCT4/IDCT4 function.
@@ -2335,7 +2238,6 @@ void arm_rfft_fast_f32(
     arm_cfft_radix4_instance_q15 *pCfft; /**< points to the complex FFT instance. */
   } arm_dct4_instance_q15;
 
-
   /**
    * @brief  Initialization function for the Q15 DCT4/IDCT4.
    * @param[in,out] S          points to an instance of Q15 DCT4/IDCT4 structure.
@@ -2347,13 +2249,12 @@ void arm_rfft_fast_f32(
    * @return      arm_status function returns ARM_MATH_SUCCESS if initialization is successful or ARM_MATH_ARGUMENT_ERROR if <code>N</code> is not a supported transform length.
    */
   arm_status arm_dct4_init_q15(
-  arm_dct4_instance_q15 * S,
-  arm_rfft_instance_q15 * S_RFFT,
-  arm_cfft_radix4_instance_q15 * S_CFFT,
-  uint16_t N,
-  uint16_t Nby2,
-  q15_t normalize);
-
+      arm_dct4_instance_q15 *S,
+      arm_rfft_instance_q15 *S_RFFT,
+      arm_cfft_radix4_instance_q15 *S_CFFT,
+      uint16_t N,
+      uint16_t Nby2,
+      q15_t normalize);
 
   /**
    * @brief Processing function for the Q15 DCT4/IDCT4.
@@ -2362,10 +2263,9 @@ void arm_rfft_fast_f32(
    * @param[in,out] pInlineBuffer  points to the in-place input and output buffer.
    */
   void arm_dct4_q15(
-  const arm_dct4_instance_q15 * S,
-  q15_t * pState,
-  q15_t * pInlineBuffer);
-
+      const arm_dct4_instance_q15 *S,
+      q15_t *pState,
+      q15_t *pInlineBuffer);
 
   /**
    * @brief Floating-point vector addition.
@@ -2375,11 +2275,10 @@ void arm_rfft_fast_f32(
    * @param[in]  blockSize  number of samples in each vector
    */
   void arm_add_f32(
-  float32_t * pSrcA,
-  float32_t * pSrcB,
-  float32_t * pDst,
-  uint32_t blockSize);
-
+      float32_t *pSrcA,
+      float32_t *pSrcB,
+      float32_t *pDst,
+      uint32_t blockSize);
 
   /**
    * @brief Q7 vector addition.
@@ -2389,11 +2288,10 @@ void arm_rfft_fast_f32(
    * @param[in]  blockSize  number of samples in each vector
    */
   void arm_add_q7(
-  q7_t * pSrcA,
-  q7_t * pSrcB,
-  q7_t * pDst,
-  uint32_t blockSize);
-
+      q7_t *pSrcA,
+      q7_t *pSrcB,
+      q7_t *pDst,
+      uint32_t blockSize);
 
   /**
    * @brief Q15 vector addition.
@@ -2403,11 +2301,10 @@ void arm_rfft_fast_f32(
    * @param[in]  blockSize  number of samples in each vector
    */
   void arm_add_q15(
-  q15_t * pSrcA,
-  q15_t * pSrcB,
-  q15_t * pDst,
-  uint32_t blockSize);
-
+      q15_t *pSrcA,
+      q15_t *pSrcB,
+      q15_t *pDst,
+      uint32_t blockSize);
 
   /**
    * @brief Q31 vector addition.
@@ -2417,11 +2314,10 @@ void arm_rfft_fast_f32(
    * @param[in]  blockSize  number of samples in each vector
    */
   void arm_add_q31(
-  q31_t * pSrcA,
-  q31_t * pSrcB,
-  q31_t * pDst,
-  uint32_t blockSize);
-
+      q31_t *pSrcA,
+      q31_t *pSrcB,
+      q31_t *pDst,
+      uint32_t blockSize);
 
   /**
    * @brief Floating-point vector subtraction.
@@ -2431,11 +2327,10 @@ void arm_rfft_fast_f32(
    * @param[in]  blockSize  number of samples in each vector
    */
   void arm_sub_f32(
-  float32_t * pSrcA,
-  float32_t * pSrcB,
-  float32_t * pDst,
-  uint32_t blockSize);
-
+      float32_t *pSrcA,
+      float32_t *pSrcB,
+      float32_t *pDst,
+      uint32_t blockSize);
 
   /**
    * @brief Q7 vector subtraction.
@@ -2445,11 +2340,10 @@ void arm_rfft_fast_f32(
    * @param[in]  blockSize  number of samples in each vector
    */
   void arm_sub_q7(
-  q7_t * pSrcA,
-  q7_t * pSrcB,
-  q7_t * pDst,
-  uint32_t blockSize);
-
+      q7_t *pSrcA,
+      q7_t *pSrcB,
+      q7_t *pDst,
+      uint32_t blockSize);
 
   /**
    * @brief Q15 vector subtraction.
@@ -2459,11 +2353,10 @@ void arm_rfft_fast_f32(
    * @param[in]  blockSize  number of samples in each vector
    */
   void arm_sub_q15(
-  q15_t * pSrcA,
-  q15_t * pSrcB,
-  q15_t * pDst,
-  uint32_t blockSize);
-
+      q15_t *pSrcA,
+      q15_t *pSrcB,
+      q15_t *pDst,
+      uint32_t blockSize);
 
   /**
    * @brief Q31 vector subtraction.
@@ -2473,11 +2366,10 @@ void arm_rfft_fast_f32(
    * @param[in]  blockSize  number of samples in each vector
    */
   void arm_sub_q31(
-  q31_t * pSrcA,
-  q31_t * pSrcB,
-  q31_t * pDst,
-  uint32_t blockSize);
-
+      q31_t *pSrcA,
+      q31_t *pSrcB,
+      q31_t *pDst,
+      uint32_t blockSize);
 
   /**
    * @brief Multiplies a floating-point vector by a scalar.
@@ -2487,11 +2379,10 @@ void arm_rfft_fast_f32(
    * @param[in]  blockSize  number of samples in the vector
    */
   void arm_scale_f32(
-  float32_t * pSrc,
-  float32_t scale,
-  float32_t * pDst,
-  uint32_t blockSize);
-
+      float32_t *pSrc,
+      float32_t scale,
+      float32_t *pDst,
+      uint32_t blockSize);
 
   /**
    * @brief Multiplies a Q7 vector by a scalar.
@@ -2502,12 +2393,11 @@ void arm_rfft_fast_f32(
    * @param[in]  blockSize   number of samples in the vector
    */
   void arm_scale_q7(
-  q7_t * pSrc,
-  q7_t scaleFract,
-  int8_t shift,
-  q7_t * pDst,
-  uint32_t blockSize);
-
+      q7_t *pSrc,
+      q7_t scaleFract,
+      int8_t shift,
+      q7_t *pDst,
+      uint32_t blockSize);
 
   /**
    * @brief Multiplies a Q15 vector by a scalar.
@@ -2518,12 +2408,11 @@ void arm_rfft_fast_f32(
    * @param[in]  blockSize   number of samples in the vector
    */
   void arm_scale_q15(
-  q15_t * pSrc,
-  q15_t scaleFract,
-  int8_t shift,
-  q15_t * pDst,
-  uint32_t blockSize);
-
+      q15_t *pSrc,
+      q15_t scaleFract,
+      int8_t shift,
+      q15_t *pDst,
+      uint32_t blockSize);
 
   /**
    * @brief Multiplies a Q31 vector by a scalar.
@@ -2534,12 +2423,11 @@ void arm_rfft_fast_f32(
    * @param[in]  blockSize   number of samples in the vector
    */
   void arm_scale_q31(
-  q31_t * pSrc,
-  q31_t scaleFract,
-  int8_t shift,
-  q31_t * pDst,
-  uint32_t blockSize);
-
+      q31_t *pSrc,
+      q31_t scaleFract,
+      int8_t shift,
+      q31_t *pDst,
+      uint32_t blockSize);
 
   /**
    * @brief Q7 vector absolute value.
@@ -2548,10 +2436,9 @@ void arm_rfft_fast_f32(
    * @param[in]  blockSize  number of samples in each vector
    */
   void arm_abs_q7(
-  q7_t * pSrc,
-  q7_t * pDst,
-  uint32_t blockSize);
-
+      q7_t *pSrc,
+      q7_t *pDst,
+      uint32_t blockSize);
 
   /**
    * @brief Floating-point vector absolute value.
@@ -2560,10 +2447,9 @@ void arm_rfft_fast_f32(
    * @param[in]  blockSize  number of samples in each vector
    */
   void arm_abs_f32(
-  float32_t * pSrc,
-  float32_t * pDst,
-  uint32_t blockSize);
-
+      float32_t *pSrc,
+      float32_t *pDst,
+      uint32_t blockSize);
 
   /**
    * @brief Q15 vector absolute value.
@@ -2572,10 +2458,9 @@ void arm_rfft_fast_f32(
    * @param[in]  blockSize  number of samples in each vector
    */
   void arm_abs_q15(
-  q15_t * pSrc,
-  q15_t * pDst,
-  uint32_t blockSize);
-
+      q15_t *pSrc,
+      q15_t *pDst,
+      uint32_t blockSize);
 
   /**
    * @brief Q31 vector absolute value.
@@ -2584,10 +2469,9 @@ void arm_rfft_fast_f32(
    * @param[in]  blockSize  number of samples in each vector
    */
   void arm_abs_q31(
-  q31_t * pSrc,
-  q31_t * pDst,
-  uint32_t blockSize);
-
+      q31_t *pSrc,
+      q31_t *pDst,
+      uint32_t blockSize);
 
   /**
    * @brief Dot product of floating-point vectors.
@@ -2597,11 +2481,10 @@ void arm_rfft_fast_f32(
    * @param[out] result     output result returned here
    */
   void arm_dot_prod_f32(
-  float32_t * pSrcA,
-  float32_t * pSrcB,
-  uint32_t blockSize,
-  float32_t * result);
-
+      float32_t *pSrcA,
+      float32_t *pSrcB,
+      uint32_t blockSize,
+      float32_t *result);
 
   /**
    * @brief Dot product of Q7 vectors.
@@ -2611,11 +2494,10 @@ void arm_rfft_fast_f32(
    * @param[out] result     output result returned here
    */
   void arm_dot_prod_q7(
-  q7_t * pSrcA,
-  q7_t * pSrcB,
-  uint32_t blockSize,
-  q31_t * result);
-
+      q7_t *pSrcA,
+      q7_t *pSrcB,
+      uint32_t blockSize,
+      q31_t *result);
 
   /**
    * @brief Dot product of Q15 vectors.
@@ -2625,11 +2507,10 @@ void arm_rfft_fast_f32(
    * @param[out] result     output result returned here
    */
   void arm_dot_prod_q15(
-  q15_t * pSrcA,
-  q15_t * pSrcB,
-  uint32_t blockSize,
-  q63_t * result);
-
+      q15_t *pSrcA,
+      q15_t *pSrcB,
+      uint32_t blockSize,
+      q63_t *result);
 
   /**
    * @brief Dot product of Q31 vectors.
@@ -2639,11 +2520,10 @@ void arm_rfft_fast_f32(
    * @param[out] result     output result returned here
    */
   void arm_dot_prod_q31(
-  q31_t * pSrcA,
-  q31_t * pSrcB,
-  uint32_t blockSize,
-  q63_t * result);
-
+      q31_t *pSrcA,
+      q31_t *pSrcB,
+      uint32_t blockSize,
+      q63_t *result);
 
   /**
    * @brief  Shifts the elements of a Q7 vector a specified number of bits.
@@ -2653,11 +2533,10 @@ void arm_rfft_fast_f32(
    * @param[in]  blockSize  number of samples in the vector
    */
   void arm_shift_q7(
-  q7_t * pSrc,
-  int8_t shiftBits,
-  q7_t * pDst,
-  uint32_t blockSize);
-
+      q7_t *pSrc,
+      int8_t shiftBits,
+      q7_t *pDst,
+      uint32_t blockSize);
 
   /**
    * @brief  Shifts the elements of a Q15 vector a specified number of bits.
@@ -2667,11 +2546,10 @@ void arm_rfft_fast_f32(
    * @param[in]  blockSize  number of samples in the vector
    */
   void arm_shift_q15(
-  q15_t * pSrc,
-  int8_t shiftBits,
-  q15_t * pDst,
-  uint32_t blockSize);
-
+      q15_t *pSrc,
+      int8_t shiftBits,
+      q15_t *pDst,
+      uint32_t blockSize);
 
   /**
    * @brief  Shifts the elements of a Q31 vector a specified number of bits.
@@ -2681,11 +2559,10 @@ void arm_rfft_fast_f32(
    * @param[in]  blockSize  number of samples in the vector
    */
   void arm_shift_q31(
-  q31_t * pSrc,
-  int8_t shiftBits,
-  q31_t * pDst,
-  uint32_t blockSize);
-
+      q31_t *pSrc,
+      int8_t shiftBits,
+      q31_t *pDst,
+      uint32_t blockSize);
 
   /**
    * @brief  Adds a constant offset to a floating-point vector.
@@ -2695,11 +2572,10 @@ void arm_rfft_fast_f32(
    * @param[in]  blockSize  number of samples in the vector
    */
   void arm_offset_f32(
-  float32_t * pSrc,
-  float32_t offset,
-  float32_t * pDst,
-  uint32_t blockSize);
-
+      float32_t *pSrc,
+      float32_t offset,
+      float32_t *pDst,
+      uint32_t blockSize);
 
   /**
    * @brief  Adds a constant offset to a Q7 vector.
@@ -2709,11 +2585,10 @@ void arm_rfft_fast_f32(
    * @param[in]  blockSize  number of samples in the vector
    */
   void arm_offset_q7(
-  q7_t * pSrc,
-  q7_t offset,
-  q7_t * pDst,
-  uint32_t blockSize);
-
+      q7_t *pSrc,
+      q7_t offset,
+      q7_t *pDst,
+      uint32_t blockSize);
 
   /**
    * @brief  Adds a constant offset to a Q15 vector.
@@ -2723,11 +2598,10 @@ void arm_rfft_fast_f32(
    * @param[in]  blockSize  number of samples in the vector
    */
   void arm_offset_q15(
-  q15_t * pSrc,
-  q15_t offset,
-  q15_t * pDst,
-  uint32_t blockSize);
-
+      q15_t *pSrc,
+      q15_t offset,
+      q15_t *pDst,
+      uint32_t blockSize);
 
   /**
    * @brief  Adds a constant offset to a Q31 vector.
@@ -2737,11 +2611,10 @@ void arm_rfft_fast_f32(
    * @param[in]  blockSize  number of samples in the vector
    */
   void arm_offset_q31(
-  q31_t * pSrc,
-  q31_t offset,
-  q31_t * pDst,
-  uint32_t blockSize);
-
+      q31_t *pSrc,
+      q31_t offset,
+      q31_t *pDst,
+      uint32_t blockSize);
 
   /**
    * @brief  Negates the elements of a floating-point vector.
@@ -2750,10 +2623,9 @@ void arm_rfft_fast_f32(
    * @param[in]  blockSize  number of samples in the vector
    */
   void arm_negate_f32(
-  float32_t * pSrc,
-  float32_t * pDst,
-  uint32_t blockSize);
-
+      float32_t *pSrc,
+      float32_t *pDst,
+      uint32_t blockSize);
 
   /**
    * @brief  Negates the elements of a Q7 vector.
@@ -2762,10 +2634,9 @@ void arm_rfft_fast_f32(
    * @param[in]  blockSize  number of samples in the vector
    */
   void arm_negate_q7(
-  q7_t * pSrc,
-  q7_t * pDst,
-  uint32_t blockSize);
-
+      q7_t *pSrc,
+      q7_t *pDst,
+      uint32_t blockSize);
 
   /**
    * @brief  Negates the elements of a Q15 vector.
@@ -2774,10 +2645,9 @@ void arm_rfft_fast_f32(
    * @param[in]  blockSize  number of samples in the vector
    */
   void arm_negate_q15(
-  q15_t * pSrc,
-  q15_t * pDst,
-  uint32_t blockSize);
-
+      q15_t *pSrc,
+      q15_t *pDst,
+      uint32_t blockSize);
 
   /**
    * @brief  Negates the elements of a Q31 vector.
@@ -2786,10 +2656,9 @@ void arm_rfft_fast_f32(
    * @param[in]  blockSize  number of samples in the vector
    */
   void arm_negate_q31(
-  q31_t * pSrc,
-  q31_t * pDst,
-  uint32_t blockSize);
-
+      q31_t *pSrc,
+      q31_t *pDst,
+      uint32_t blockSize);
 
   /**
    * @brief  Copies the elements of a floating-point vector.
@@ -2798,10 +2667,9 @@ void arm_rfft_fast_f32(
    * @param[in]  blockSize  number of samples to process
    */
   void arm_copy_f32(
-  float32_t * pSrc,
-  float32_t * pDst,
-  uint32_t blockSize);
-
+      float32_t *pSrc,
+      float32_t *pDst,
+      uint32_t blockSize);
 
   /**
    * @brief  Copies the elements of a Q7 vector.
@@ -2810,10 +2678,9 @@ void arm_rfft_fast_f32(
    * @param[in]  blockSize  number of samples to process
    */
   void arm_copy_q7(
-  q7_t * pSrc,
-  q7_t * pDst,
-  uint32_t blockSize);
-
+      q7_t *pSrc,
+      q7_t *pDst,
+      uint32_t blockSize);
 
   /**
    * @brief  Copies the elements of a Q15 vector.
@@ -2822,10 +2689,9 @@ void arm_rfft_fast_f32(
    * @param[in]  blockSize  number of samples to process
    */
   void arm_copy_q15(
-  q15_t * pSrc,
-  q15_t * pDst,
-  uint32_t blockSize);
-
+      q15_t *pSrc,
+      q15_t *pDst,
+      uint32_t blockSize);
 
   /**
    * @brief  Copies the elements of a Q31 vector.
@@ -2834,10 +2700,9 @@ void arm_rfft_fast_f32(
    * @param[in]  blockSize  number of samples to process
    */
   void arm_copy_q31(
-  q31_t * pSrc,
-  q31_t * pDst,
-  uint32_t blockSize);
-
+      q31_t *pSrc,
+      q31_t *pDst,
+      uint32_t blockSize);
 
   /**
    * @brief  Fills a constant value into a floating-point vector.
@@ -2846,10 +2711,9 @@ void arm_rfft_fast_f32(
    * @param[in]  blockSize  number of samples to process
    */
   void arm_fill_f32(
-  float32_t value,
-  float32_t * pDst,
-  uint32_t blockSize);
-
+      float32_t value,
+      float32_t *pDst,
+      uint32_t blockSize);
 
   /**
    * @brief  Fills a constant value into a Q7 vector.
@@ -2858,10 +2722,9 @@ void arm_rfft_fast_f32(
    * @param[in]  blockSize  number of samples to process
    */
   void arm_fill_q7(
-  q7_t value,
-  q7_t * pDst,
-  uint32_t blockSize);
-
+      q7_t value,
+      q7_t *pDst,
+      uint32_t blockSize);
 
   /**
    * @brief  Fills a constant value into a Q15 vector.
@@ -2870,10 +2733,9 @@ void arm_rfft_fast_f32(
    * @param[in]  blockSize  number of samples to process
    */
   void arm_fill_q15(
-  q15_t value,
-  q15_t * pDst,
-  uint32_t blockSize);
-
+      q15_t value,
+      q15_t *pDst,
+      uint32_t blockSize);
 
   /**
    * @brief  Fills a constant value into a Q31 vector.
@@ -2882,12 +2744,11 @@ void arm_rfft_fast_f32(
    * @param[in]  blockSize  number of samples to process
    */
   void arm_fill_q31(
-  q31_t value,
-  q31_t * pDst,
-  uint32_t blockSize);
+      q31_t value,
+      q31_t *pDst,
+      uint32_t blockSize);
 
-
-/**
+  /**
  * @brief Convolution of floating-point sequences.
  * @param[in]  pSrcA    points to the first input sequence.
  * @param[in]  srcALen  length of the first input sequence.
@@ -2896,12 +2757,11 @@ void arm_rfft_fast_f32(
  * @param[out] pDst     points to the location where the output result is written.  Length srcALen+srcBLen-1.
  */
   void arm_conv_f32(
-  float32_t * pSrcA,
-  uint32_t srcALen,
-  float32_t * pSrcB,
-  uint32_t srcBLen,
-  float32_t * pDst);
-
+      float32_t *pSrcA,
+      uint32_t srcALen,
+      float32_t *pSrcB,
+      uint32_t srcBLen,
+      float32_t *pDst);
 
   /**
    * @brief Convolution of Q15 sequences.
@@ -2914,16 +2774,15 @@ void arm_rfft_fast_f32(
    * @param[in]  pScratch2  points to scratch buffer of size min(srcALen, srcBLen).
    */
   void arm_conv_opt_q15(
-  q15_t * pSrcA,
-  uint32_t srcALen,
-  q15_t * pSrcB,
-  uint32_t srcBLen,
-  q15_t * pDst,
-  q15_t * pScratch1,
-  q15_t * pScratch2);
+      q15_t *pSrcA,
+      uint32_t srcALen,
+      q15_t *pSrcB,
+      uint32_t srcBLen,
+      q15_t *pDst,
+      q15_t *pScratch1,
+      q15_t *pScratch2);
 
-
-/**
+  /**
  * @brief Convolution of Q15 sequences.
  * @param[in]  pSrcA    points to the first input sequence.
  * @param[in]  srcALen  length of the first input sequence.
@@ -2932,12 +2791,11 @@ void arm_rfft_fast_f32(
  * @param[out] pDst     points to the location where the output result is written.  Length srcALen+srcBLen-1.
  */
   void arm_conv_q15(
-  q15_t * pSrcA,
-  uint32_t srcALen,
-  q15_t * pSrcB,
-  uint32_t srcBLen,
-  q15_t * pDst);
-
+      q15_t *pSrcA,
+      uint32_t srcALen,
+      q15_t *pSrcB,
+      uint32_t srcBLen,
+      q15_t *pDst);
 
   /**
    * @brief Convolution of Q15 sequences (fast version) for Cortex-M3 and Cortex-M4
@@ -2948,12 +2806,11 @@ void arm_rfft_fast_f32(
    * @param[out] pDst     points to the block of output data  Length srcALen+srcBLen-1.
    */
   void arm_conv_fast_q15(
-          q15_t * pSrcA,
-          uint32_t srcALen,
-          q15_t * pSrcB,
-          uint32_t srcBLen,
-          q15_t * pDst);
-
+      q15_t *pSrcA,
+      uint32_t srcALen,
+      q15_t *pSrcB,
+      uint32_t srcBLen,
+      q15_t *pDst);
 
   /**
    * @brief Convolution of Q15 sequences (fast version) for Cortex-M3 and Cortex-M4
@@ -2966,14 +2823,13 @@ void arm_rfft_fast_f32(
    * @param[in]  pScratch2  points to scratch buffer of size min(srcALen, srcBLen).
    */
   void arm_conv_fast_opt_q15(
-  q15_t * pSrcA,
-  uint32_t srcALen,
-  q15_t * pSrcB,
-  uint32_t srcBLen,
-  q15_t * pDst,
-  q15_t * pScratch1,
-  q15_t * pScratch2);
-
+      q15_t *pSrcA,
+      uint32_t srcALen,
+      q15_t *pSrcB,
+      uint32_t srcBLen,
+      q15_t *pDst,
+      q15_t *pScratch1,
+      q15_t *pScratch2);
 
   /**
    * @brief Convolution of Q31 sequences.
@@ -2984,12 +2840,11 @@ void arm_rfft_fast_f32(
    * @param[out] pDst     points to the block of output data  Length srcALen+srcBLen-1.
    */
   void arm_conv_q31(
-  q31_t * pSrcA,
-  uint32_t srcALen,
-  q31_t * pSrcB,
-  uint32_t srcBLen,
-  q31_t * pDst);
-
+      q31_t *pSrcA,
+      uint32_t srcALen,
+      q31_t *pSrcB,
+      uint32_t srcBLen,
+      q31_t *pDst);
 
   /**
    * @brief Convolution of Q31 sequences (fast version) for Cortex-M3 and Cortex-M4
@@ -3000,14 +2855,13 @@ void arm_rfft_fast_f32(
    * @param[out] pDst     points to the block of output data  Length srcALen+srcBLen-1.
    */
   void arm_conv_fast_q31(
-  q31_t * pSrcA,
-  uint32_t srcALen,
-  q31_t * pSrcB,
-  uint32_t srcBLen,
-  q31_t * pDst);
+      q31_t *pSrcA,
+      uint32_t srcALen,
+      q31_t *pSrcB,
+      uint32_t srcBLen,
+      q31_t *pDst);
 
-
-    /**
+  /**
    * @brief Convolution of Q7 sequences.
    * @param[in]  pSrcA      points to the first input sequence.
    * @param[in]  srcALen    length of the first input sequence.
@@ -3018,14 +2872,13 @@ void arm_rfft_fast_f32(
    * @param[in]  pScratch2  points to scratch buffer (of type q15_t) of size min(srcALen, srcBLen).
    */
   void arm_conv_opt_q7(
-  q7_t * pSrcA,
-  uint32_t srcALen,
-  q7_t * pSrcB,
-  uint32_t srcBLen,
-  q7_t * pDst,
-  q15_t * pScratch1,
-  q15_t * pScratch2);
-
+      q7_t *pSrcA,
+      uint32_t srcALen,
+      q7_t *pSrcB,
+      uint32_t srcBLen,
+      q7_t *pDst,
+      q15_t *pScratch1,
+      q15_t *pScratch2);
 
   /**
    * @brief Convolution of Q7 sequences.
@@ -3036,12 +2889,11 @@ void arm_rfft_fast_f32(
    * @param[out] pDst     points to the block of output data  Length srcALen+srcBLen-1.
    */
   void arm_conv_q7(
-  q7_t * pSrcA,
-  uint32_t srcALen,
-  q7_t * pSrcB,
-  uint32_t srcBLen,
-  q7_t * pDst);
-
+      q7_t *pSrcA,
+      uint32_t srcALen,
+      q7_t *pSrcB,
+      uint32_t srcBLen,
+      q7_t *pDst);
 
   /**
    * @brief Partial convolution of floating-point sequences.
@@ -3055,14 +2907,13 @@ void arm_rfft_fast_f32(
    * @return  Returns either ARM_MATH_SUCCESS if the function completed correctly or ARM_MATH_ARGUMENT_ERROR if the requested subset is not in the range [0 srcALen+srcBLen-2].
    */
   arm_status arm_conv_partial_f32(
-  float32_t * pSrcA,
-  uint32_t srcALen,
-  float32_t * pSrcB,
-  uint32_t srcBLen,
-  float32_t * pDst,
-  uint32_t firstIndex,
-  uint32_t numPoints);
-
+      float32_t *pSrcA,
+      uint32_t srcALen,
+      float32_t *pSrcB,
+      uint32_t srcBLen,
+      float32_t *pDst,
+      uint32_t firstIndex,
+      uint32_t numPoints);
 
   /**
    * @brief Partial convolution of Q15 sequences.
@@ -3078,16 +2929,15 @@ void arm_rfft_fast_f32(
    * @return  Returns either ARM_MATH_SUCCESS if the function completed correctly or ARM_MATH_ARGUMENT_ERROR if the requested subset is not in the range [0 srcALen+srcBLen-2].
    */
   arm_status arm_conv_partial_opt_q15(
-  q15_t * pSrcA,
-  uint32_t srcALen,
-  q15_t * pSrcB,
-  uint32_t srcBLen,
-  q15_t * pDst,
-  uint32_t firstIndex,
-  uint32_t numPoints,
-  q15_t * pScratch1,
-  q15_t * pScratch2);
-
+      q15_t *pSrcA,
+      uint32_t srcALen,
+      q15_t *pSrcB,
+      uint32_t srcBLen,
+      q15_t *pDst,
+      uint32_t firstIndex,
+      uint32_t numPoints,
+      q15_t *pScratch1,
+      q15_t *pScratch2);
 
   /**
    * @brief Partial convolution of Q15 sequences.
@@ -3101,14 +2951,13 @@ void arm_rfft_fast_f32(
    * @return  Returns either ARM_MATH_SUCCESS if the function completed correctly or ARM_MATH_ARGUMENT_ERROR if the requested subset is not in the range [0 srcALen+srcBLen-2].
    */
   arm_status arm_conv_partial_q15(
-  q15_t * pSrcA,
-  uint32_t srcALen,
-  q15_t * pSrcB,
-  uint32_t srcBLen,
-  q15_t * pDst,
-  uint32_t firstIndex,
-  uint32_t numPoints);
-
+      q15_t *pSrcA,
+      uint32_t srcALen,
+      q15_t *pSrcB,
+      uint32_t srcBLen,
+      q15_t *pDst,
+      uint32_t firstIndex,
+      uint32_t numPoints);
 
   /**
    * @brief Partial convolution of Q15 sequences (fast version) for Cortex-M3 and Cortex-M4
@@ -3122,14 +2971,13 @@ void arm_rfft_fast_f32(
    * @return  Returns either ARM_MATH_SUCCESS if the function completed correctly or ARM_MATH_ARGUMENT_ERROR if the requested subset is not in the range [0 srcALen+srcBLen-2].
    */
   arm_status arm_conv_partial_fast_q15(
-  q15_t * pSrcA,
-  uint32_t srcALen,
-  q15_t * pSrcB,
-  uint32_t srcBLen,
-  q15_t * pDst,
-  uint32_t firstIndex,
-  uint32_t numPoints);
-
+      q15_t *pSrcA,
+      uint32_t srcALen,
+      q15_t *pSrcB,
+      uint32_t srcBLen,
+      q15_t *pDst,
+      uint32_t firstIndex,
+      uint32_t numPoints);
 
   /**
    * @brief Partial convolution of Q15 sequences (fast version) for Cortex-M3 and Cortex-M4
@@ -3145,16 +2993,15 @@ void arm_rfft_fast_f32(
    * @return  Returns either ARM_MATH_SUCCESS if the function completed correctly or ARM_MATH_ARGUMENT_ERROR if the requested subset is not in the range [0 srcALen+srcBLen-2].
    */
   arm_status arm_conv_partial_fast_opt_q15(
-  q15_t * pSrcA,
-  uint32_t srcALen,
-  q15_t * pSrcB,
-  uint32_t srcBLen,
-  q15_t * pDst,
-  uint32_t firstIndex,
-  uint32_t numPoints,
-  q15_t * pScratch1,
-  q15_t * pScratch2);
-
+      q15_t *pSrcA,
+      uint32_t srcALen,
+      q15_t *pSrcB,
+      uint32_t srcBLen,
+      q15_t *pDst,
+      uint32_t firstIndex,
+      uint32_t numPoints,
+      q15_t *pScratch1,
+      q15_t *pScratch2);
 
   /**
    * @brief Partial convolution of Q31 sequences.
@@ -3168,14 +3015,13 @@ void arm_rfft_fast_f32(
    * @return  Returns either ARM_MATH_SUCCESS if the function completed correctly or ARM_MATH_ARGUMENT_ERROR if the requested subset is not in the range [0 srcALen+srcBLen-2].
    */
   arm_status arm_conv_partial_q31(
-  q31_t * pSrcA,
-  uint32_t srcALen,
-  q31_t * pSrcB,
-  uint32_t srcBLen,
-  q31_t * pDst,
-  uint32_t firstIndex,
-  uint32_t numPoints);
-
+      q31_t *pSrcA,
+      uint32_t srcALen,
+      q31_t *pSrcB,
+      uint32_t srcBLen,
+      q31_t *pDst,
+      uint32_t firstIndex,
+      uint32_t numPoints);
 
   /**
    * @brief Partial convolution of Q31 sequences (fast version) for Cortex-M3 and Cortex-M4
@@ -3189,14 +3035,13 @@ void arm_rfft_fast_f32(
    * @return  Returns either ARM_MATH_SUCCESS if the function completed correctly or ARM_MATH_ARGUMENT_ERROR if the requested subset is not in the range [0 srcALen+srcBLen-2].
    */
   arm_status arm_conv_partial_fast_q31(
-  q31_t * pSrcA,
-  uint32_t srcALen,
-  q31_t * pSrcB,
-  uint32_t srcBLen,
-  q31_t * pDst,
-  uint32_t firstIndex,
-  uint32_t numPoints);
-
+      q31_t *pSrcA,
+      uint32_t srcALen,
+      q31_t *pSrcB,
+      uint32_t srcBLen,
+      q31_t *pDst,
+      uint32_t firstIndex,
+      uint32_t numPoints);
 
   /**
    * @brief Partial convolution of Q7 sequences
@@ -3212,18 +3057,17 @@ void arm_rfft_fast_f32(
    * @return  Returns either ARM_MATH_SUCCESS if the function completed correctly or ARM_MATH_ARGUMENT_ERROR if the requested subset is not in the range [0 srcALen+srcBLen-2].
    */
   arm_status arm_conv_partial_opt_q7(
-  q7_t * pSrcA,
-  uint32_t srcALen,
-  q7_t * pSrcB,
-  uint32_t srcBLen,
-  q7_t * pDst,
-  uint32_t firstIndex,
-  uint32_t numPoints,
-  q15_t * pScratch1,
-  q15_t * pScratch2);
+      q7_t *pSrcA,
+      uint32_t srcALen,
+      q7_t *pSrcB,
+      uint32_t srcBLen,
+      q7_t *pDst,
+      uint32_t firstIndex,
+      uint32_t numPoints,
+      q15_t *pScratch1,
+      q15_t *pScratch2);
 
-
-/**
+  /**
    * @brief Partial convolution of Q7 sequences.
    * @param[in]  pSrcA       points to the first input sequence.
    * @param[in]  srcALen     length of the first input sequence.
@@ -3235,24 +3079,23 @@ void arm_rfft_fast_f32(
    * @return  Returns either ARM_MATH_SUCCESS if the function completed correctly or ARM_MATH_ARGUMENT_ERROR if the requested subset is not in the range [0 srcALen+srcBLen-2].
    */
   arm_status arm_conv_partial_q7(
-  q7_t * pSrcA,
-  uint32_t srcALen,
-  q7_t * pSrcB,
-  uint32_t srcBLen,
-  q7_t * pDst,
-  uint32_t firstIndex,
-  uint32_t numPoints);
-
+      q7_t *pSrcA,
+      uint32_t srcALen,
+      q7_t *pSrcB,
+      uint32_t srcBLen,
+      q7_t *pDst,
+      uint32_t firstIndex,
+      uint32_t numPoints);
 
   /**
    * @brief Instance structure for the Q15 FIR decimator.
    */
   typedef struct
   {
-    uint8_t M;                  /**< decimation factor. */
-    uint16_t numTaps;           /**< number of coefficients in the filter. */
-    q15_t *pCoeffs;             /**< points to the coefficient array. The array is of length numTaps.*/
-    q15_t *pState;              /**< points to the state variable array. The array is of length numTaps+blockSize-1. */
+    uint8_t M;        /**< decimation factor. */
+    uint16_t numTaps; /**< number of coefficients in the filter. */
+    q15_t *pCoeffs;   /**< points to the coefficient array. The array is of length numTaps.*/
+    q15_t *pState;    /**< points to the state variable array. The array is of length numTaps+blockSize-1. */
   } arm_fir_decimate_instance_q15;
 
   /**
@@ -3260,10 +3103,10 @@ void arm_rfft_fast_f32(
    */
   typedef struct
   {
-    uint8_t M;                  /**< decimation factor. */
-    uint16_t numTaps;           /**< number of coefficients in the filter. */
-    q31_t *pCoeffs;             /**< points to the coefficient array. The array is of length numTaps.*/
-    q31_t *pState;              /**< points to the state variable array. The array is of length numTaps+blockSize-1. */
+    uint8_t M;        /**< decimation factor. */
+    uint16_t numTaps; /**< number of coefficients in the filter. */
+    q31_t *pCoeffs;   /**< points to the coefficient array. The array is of length numTaps.*/
+    q31_t *pState;    /**< points to the state variable array. The array is of length numTaps+blockSize-1. */
   } arm_fir_decimate_instance_q31;
 
   /**
@@ -3271,12 +3114,11 @@ void arm_rfft_fast_f32(
    */
   typedef struct
   {
-    uint8_t M;                  /**< decimation factor. */
-    uint16_t numTaps;           /**< number of coefficients in the filter. */
-    float32_t *pCoeffs;         /**< points to the coefficient array. The array is of length numTaps.*/
-    float32_t *pState;          /**< points to the state variable array. The array is of length numTaps+blockSize-1. */
+    uint8_t M;          /**< decimation factor. */
+    uint16_t numTaps;   /**< number of coefficients in the filter. */
+    float32_t *pCoeffs; /**< points to the coefficient array. The array is of length numTaps.*/
+    float32_t *pState;  /**< points to the state variable array. The array is of length numTaps+blockSize-1. */
   } arm_fir_decimate_instance_f32;
-
 
   /**
    * @brief Processing function for the floating-point FIR decimator.
@@ -3286,11 +3128,10 @@ void arm_rfft_fast_f32(
    * @param[in]  blockSize  number of input samples to process per call.
    */
   void arm_fir_decimate_f32(
-  const arm_fir_decimate_instance_f32 * S,
-  float32_t * pSrc,
-  float32_t * pDst,
-  uint32_t blockSize);
-
+      const arm_fir_decimate_instance_f32 *S,
+      float32_t *pSrc,
+      float32_t *pDst,
+      uint32_t blockSize);
 
   /**
    * @brief  Initialization function for the floating-point FIR decimator.
@@ -3304,13 +3145,12 @@ void arm_rfft_fast_f32(
    * <code>blockSize</code> is not a multiple of <code>M</code>.
    */
   arm_status arm_fir_decimate_init_f32(
-  arm_fir_decimate_instance_f32 * S,
-  uint16_t numTaps,
-  uint8_t M,
-  float32_t * pCoeffs,
-  float32_t * pState,
-  uint32_t blockSize);
-
+      arm_fir_decimate_instance_f32 *S,
+      uint16_t numTaps,
+      uint8_t M,
+      float32_t *pCoeffs,
+      float32_t *pState,
+      uint32_t blockSize);
 
   /**
    * @brief Processing function for the Q15 FIR decimator.
@@ -3320,11 +3160,10 @@ void arm_rfft_fast_f32(
    * @param[in]  blockSize  number of input samples to process per call.
    */
   void arm_fir_decimate_q15(
-  const arm_fir_decimate_instance_q15 * S,
-  q15_t * pSrc,
-  q15_t * pDst,
-  uint32_t blockSize);
-
+      const arm_fir_decimate_instance_q15 *S,
+      q15_t *pSrc,
+      q15_t *pDst,
+      uint32_t blockSize);
 
   /**
    * @brief Processing function for the Q15 FIR decimator (fast variant) for Cortex-M3 and Cortex-M4.
@@ -3334,11 +3173,10 @@ void arm_rfft_fast_f32(
    * @param[in]  blockSize  number of input samples to process per call.
    */
   void arm_fir_decimate_fast_q15(
-  const arm_fir_decimate_instance_q15 * S,
-  q15_t * pSrc,
-  q15_t * pDst,
-  uint32_t blockSize);
-
+      const arm_fir_decimate_instance_q15 *S,
+      q15_t *pSrc,
+      q15_t *pDst,
+      uint32_t blockSize);
 
   /**
    * @brief  Initialization function for the Q15 FIR decimator.
@@ -3352,13 +3190,12 @@ void arm_rfft_fast_f32(
    * <code>blockSize</code> is not a multiple of <code>M</code>.
    */
   arm_status arm_fir_decimate_init_q15(
-  arm_fir_decimate_instance_q15 * S,
-  uint16_t numTaps,
-  uint8_t M,
-  q15_t * pCoeffs,
-  q15_t * pState,
-  uint32_t blockSize);
-
+      arm_fir_decimate_instance_q15 *S,
+      uint16_t numTaps,
+      uint8_t M,
+      q15_t *pCoeffs,
+      q15_t *pState,
+      uint32_t blockSize);
 
   /**
    * @brief Processing function for the Q31 FIR decimator.
@@ -3368,10 +3205,10 @@ void arm_rfft_fast_f32(
    * @param[in] blockSize number of input samples to process per call.
    */
   void arm_fir_decimate_q31(
-  const arm_fir_decimate_instance_q31 * S,
-  q31_t * pSrc,
-  q31_t * pDst,
-  uint32_t blockSize);
+      const arm_fir_decimate_instance_q31 *S,
+      q31_t *pSrc,
+      q31_t *pDst,
+      uint32_t blockSize);
 
   /**
    * @brief Processing function for the Q31 FIR decimator (fast variant) for Cortex-M3 and Cortex-M4.
@@ -3381,11 +3218,10 @@ void arm_rfft_fast_f32(
    * @param[in]  blockSize  number of input samples to process per call.
    */
   void arm_fir_decimate_fast_q31(
-  arm_fir_decimate_instance_q31 * S,
-  q31_t * pSrc,
-  q31_t * pDst,
-  uint32_t blockSize);
-
+      arm_fir_decimate_instance_q31 *S,
+      q31_t *pSrc,
+      q31_t *pDst,
+      uint32_t blockSize);
 
   /**
    * @brief  Initialization function for the Q31 FIR decimator.
@@ -3399,23 +3235,22 @@ void arm_rfft_fast_f32(
    * <code>blockSize</code> is not a multiple of <code>M</code>.
    */
   arm_status arm_fir_decimate_init_q31(
-  arm_fir_decimate_instance_q31 * S,
-  uint16_t numTaps,
-  uint8_t M,
-  q31_t * pCoeffs,
-  q31_t * pState,
-  uint32_t blockSize);
-
+      arm_fir_decimate_instance_q31 *S,
+      uint16_t numTaps,
+      uint8_t M,
+      q31_t *pCoeffs,
+      q31_t *pState,
+      uint32_t blockSize);
 
   /**
    * @brief Instance structure for the Q15 FIR interpolator.
    */
   typedef struct
   {
-    uint8_t L;                      /**< upsample factor. */
-    uint16_t phaseLength;           /**< length of each polyphase filter component. */
-    q15_t *pCoeffs;                 /**< points to the coefficient array. The array is of length L*phaseLength. */
-    q15_t *pState;                  /**< points to the state variable array. The array is of length blockSize+phaseLength-1. */
+    uint8_t L;            /**< upsample factor. */
+    uint16_t phaseLength; /**< length of each polyphase filter component. */
+    q15_t *pCoeffs;       /**< points to the coefficient array. The array is of length L*phaseLength. */
+    q15_t *pState;        /**< points to the state variable array. The array is of length blockSize+phaseLength-1. */
   } arm_fir_interpolate_instance_q15;
 
   /**
@@ -3423,10 +3258,10 @@ void arm_rfft_fast_f32(
    */
   typedef struct
   {
-    uint8_t L;                      /**< upsample factor. */
-    uint16_t phaseLength;           /**< length of each polyphase filter component. */
-    q31_t *pCoeffs;                 /**< points to the coefficient array. The array is of length L*phaseLength. */
-    q31_t *pState;                  /**< points to the state variable array. The array is of length blockSize+phaseLength-1. */
+    uint8_t L;            /**< upsample factor. */
+    uint16_t phaseLength; /**< length of each polyphase filter component. */
+    q31_t *pCoeffs;       /**< points to the coefficient array. The array is of length L*phaseLength. */
+    q31_t *pState;        /**< points to the state variable array. The array is of length blockSize+phaseLength-1. */
   } arm_fir_interpolate_instance_q31;
 
   /**
@@ -3434,12 +3269,11 @@ void arm_rfft_fast_f32(
    */
   typedef struct
   {
-    uint8_t L;                     /**< upsample factor. */
-    uint16_t phaseLength;          /**< length of each polyphase filter component. */
-    float32_t *pCoeffs;            /**< points to the coefficient array. The array is of length L*phaseLength. */
-    float32_t *pState;             /**< points to the state variable array. The array is of length phaseLength+numTaps-1. */
+    uint8_t L;            /**< upsample factor. */
+    uint16_t phaseLength; /**< length of each polyphase filter component. */
+    float32_t *pCoeffs;   /**< points to the coefficient array. The array is of length L*phaseLength. */
+    float32_t *pState;    /**< points to the state variable array. The array is of length phaseLength+numTaps-1. */
   } arm_fir_interpolate_instance_f32;
-
 
   /**
    * @brief Processing function for the Q15 FIR interpolator.
@@ -3449,11 +3283,10 @@ void arm_rfft_fast_f32(
    * @param[in]  blockSize  number of input samples to process per call.
    */
   void arm_fir_interpolate_q15(
-  const arm_fir_interpolate_instance_q15 * S,
-  q15_t * pSrc,
-  q15_t * pDst,
-  uint32_t blockSize);
-
+      const arm_fir_interpolate_instance_q15 *S,
+      q15_t *pSrc,
+      q15_t *pDst,
+      uint32_t blockSize);
 
   /**
    * @brief  Initialization function for the Q15 FIR interpolator.
@@ -3467,13 +3300,12 @@ void arm_rfft_fast_f32(
    * the filter length <code>numTaps</code> is not a multiple of the interpolation factor <code>L</code>.
    */
   arm_status arm_fir_interpolate_init_q15(
-  arm_fir_interpolate_instance_q15 * S,
-  uint8_t L,
-  uint16_t numTaps,
-  q15_t * pCoeffs,
-  q15_t * pState,
-  uint32_t blockSize);
-
+      arm_fir_interpolate_instance_q15 *S,
+      uint8_t L,
+      uint16_t numTaps,
+      q15_t *pCoeffs,
+      q15_t *pState,
+      uint32_t blockSize);
 
   /**
    * @brief Processing function for the Q31 FIR interpolator.
@@ -3483,11 +3315,10 @@ void arm_rfft_fast_f32(
    * @param[in]  blockSize  number of input samples to process per call.
    */
   void arm_fir_interpolate_q31(
-  const arm_fir_interpolate_instance_q31 * S,
-  q31_t * pSrc,
-  q31_t * pDst,
-  uint32_t blockSize);
-
+      const arm_fir_interpolate_instance_q31 *S,
+      q31_t *pSrc,
+      q31_t *pDst,
+      uint32_t blockSize);
 
   /**
    * @brief  Initialization function for the Q31 FIR interpolator.
@@ -3501,13 +3332,12 @@ void arm_rfft_fast_f32(
    * the filter length <code>numTaps</code> is not a multiple of the interpolation factor <code>L</code>.
    */
   arm_status arm_fir_interpolate_init_q31(
-  arm_fir_interpolate_instance_q31 * S,
-  uint8_t L,
-  uint16_t numTaps,
-  q31_t * pCoeffs,
-  q31_t * pState,
-  uint32_t blockSize);
-
+      arm_fir_interpolate_instance_q31 *S,
+      uint8_t L,
+      uint16_t numTaps,
+      q31_t *pCoeffs,
+      q31_t *pState,
+      uint32_t blockSize);
 
   /**
    * @brief Processing function for the floating-point FIR interpolator.
@@ -3517,11 +3347,10 @@ void arm_rfft_fast_f32(
    * @param[in]  blockSize  number of input samples to process per call.
    */
   void arm_fir_interpolate_f32(
-  const arm_fir_interpolate_instance_f32 * S,
-  float32_t * pSrc,
-  float32_t * pDst,
-  uint32_t blockSize);
-
+      const arm_fir_interpolate_instance_f32 *S,
+      float32_t *pSrc,
+      float32_t *pDst,
+      uint32_t blockSize);
 
   /**
    * @brief  Initialization function for the floating-point FIR interpolator.
@@ -3535,25 +3364,23 @@ void arm_rfft_fast_f32(
    * the filter length <code>numTaps</code> is not a multiple of the interpolation factor <code>L</code>.
    */
   arm_status arm_fir_interpolate_init_f32(
-  arm_fir_interpolate_instance_f32 * S,
-  uint8_t L,
-  uint16_t numTaps,
-  float32_t * pCoeffs,
-  float32_t * pState,
-  uint32_t blockSize);
-
+      arm_fir_interpolate_instance_f32 *S,
+      uint8_t L,
+      uint16_t numTaps,
+      float32_t *pCoeffs,
+      float32_t *pState,
+      uint32_t blockSize);
 
   /**
    * @brief Instance structure for the high precision Q31 Biquad cascade filter.
    */
   typedef struct
   {
-    uint8_t numStages;       /**< number of 2nd order stages in the filter.  Overall order is 2*numStages. */
-    q63_t *pState;           /**< points to the array of state coefficients.  The array is of length 4*numStages. */
-    q31_t *pCoeffs;          /**< points to the array of coefficients.  The array is of length 5*numStages. */
-    uint8_t postShift;       /**< additional shift, in bits, applied to each output sample. */
+    uint8_t numStages; /**< number of 2nd order stages in the filter.  Overall order is 2*numStages. */
+    q63_t *pState;     /**< points to the array of state coefficients.  The array is of length 4*numStages. */
+    q31_t *pCoeffs;    /**< points to the array of coefficients.  The array is of length 5*numStages. */
+    uint8_t postShift; /**< additional shift, in bits, applied to each output sample. */
   } arm_biquad_cas_df1_32x64_ins_q31;
-
 
   /**
    * @param[in]  S          points to an instance of the high precision Q31 Biquad cascade filter structure.
@@ -3562,11 +3389,10 @@ void arm_rfft_fast_f32(
    * @param[in]  blockSize  number of samples to process.
    */
   void arm_biquad_cas_df1_32x64_q31(
-  const arm_biquad_cas_df1_32x64_ins_q31 * S,
-  q31_t * pSrc,
-  q31_t * pDst,
-  uint32_t blockSize);
-
+      const arm_biquad_cas_df1_32x64_ins_q31 *S,
+      q31_t *pSrc,
+      q31_t *pDst,
+      uint32_t blockSize);
 
   /**
    * @param[in,out] S          points to an instance of the high precision Q31 Biquad cascade filter structure.
@@ -3576,21 +3402,20 @@ void arm_rfft_fast_f32(
    * @param[in]     postShift  shift to be applied to the output. Varies according to the coefficients format
    */
   void arm_biquad_cas_df1_32x64_init_q31(
-  arm_biquad_cas_df1_32x64_ins_q31 * S,
-  uint8_t numStages,
-  q31_t * pCoeffs,
-  q63_t * pState,
-  uint8_t postShift);
-
+      arm_biquad_cas_df1_32x64_ins_q31 *S,
+      uint8_t numStages,
+      q31_t *pCoeffs,
+      q63_t *pState,
+      uint8_t postShift);
 
   /**
    * @brief Instance structure for the floating-point transposed direct form II Biquad cascade filter.
    */
   typedef struct
   {
-    uint8_t numStages;         /**< number of 2nd order stages in the filter.  Overall order is 2*numStages. */
-    float32_t *pState;         /**< points to the array of state coefficients.  The array is of length 2*numStages. */
-    float32_t *pCoeffs;        /**< points to the array of coefficients.  The array is of length 5*numStages. */
+    uint8_t numStages;  /**< number of 2nd order stages in the filter.  Overall order is 2*numStages. */
+    float32_t *pState;  /**< points to the array of state coefficients.  The array is of length 2*numStages. */
+    float32_t *pCoeffs; /**< points to the array of coefficients.  The array is of length 5*numStages. */
   } arm_biquad_cascade_df2T_instance_f32;
 
   /**
@@ -3598,9 +3423,9 @@ void arm_rfft_fast_f32(
    */
   typedef struct
   {
-    uint8_t numStages;         /**< number of 2nd order stages in the filter.  Overall order is 2*numStages. */
-    float32_t *pState;         /**< points to the array of state coefficients.  The array is of length 4*numStages. */
-    float32_t *pCoeffs;        /**< points to the array of coefficients.  The array is of length 5*numStages. */
+    uint8_t numStages;  /**< number of 2nd order stages in the filter.  Overall order is 2*numStages. */
+    float32_t *pState;  /**< points to the array of state coefficients.  The array is of length 4*numStages. */
+    float32_t *pCoeffs; /**< points to the array of coefficients.  The array is of length 5*numStages. */
   } arm_biquad_cascade_stereo_df2T_instance_f32;
 
   /**
@@ -3608,11 +3433,10 @@ void arm_rfft_fast_f32(
    */
   typedef struct
   {
-    uint8_t numStages;         /**< number of 2nd order stages in the filter.  Overall order is 2*numStages. */
-    float64_t *pState;         /**< points to the array of state coefficients.  The array is of length 2*numStages. */
-    float64_t *pCoeffs;        /**< points to the array of coefficients.  The array is of length 5*numStages. */
+    uint8_t numStages;  /**< number of 2nd order stages in the filter.  Overall order is 2*numStages. */
+    float64_t *pState;  /**< points to the array of state coefficients.  The array is of length 2*numStages. */
+    float64_t *pCoeffs; /**< points to the array of coefficients.  The array is of length 5*numStages. */
   } arm_biquad_cascade_df2T_instance_f64;
-
 
   /**
    * @brief Processing function for the floating-point transposed direct form II Biquad cascade filter.
@@ -3622,11 +3446,10 @@ void arm_rfft_fast_f32(
    * @param[in]  blockSize  number of samples to process.
    */
   void arm_biquad_cascade_df2T_f32(
-  const arm_biquad_cascade_df2T_instance_f32 * S,
-  float32_t * pSrc,
-  float32_t * pDst,
-  uint32_t blockSize);
-
+      const arm_biquad_cascade_df2T_instance_f32 *S,
+      float32_t *pSrc,
+      float32_t *pDst,
+      uint32_t blockSize);
 
   /**
    * @brief Processing function for the floating-point transposed direct form II Biquad cascade filter. 2 channels
@@ -3636,11 +3459,10 @@ void arm_rfft_fast_f32(
    * @param[in]  blockSize  number of samples to process.
    */
   void arm_biquad_cascade_stereo_df2T_f32(
-  const arm_biquad_cascade_stereo_df2T_instance_f32 * S,
-  float32_t * pSrc,
-  float32_t * pDst,
-  uint32_t blockSize);
-
+      const arm_biquad_cascade_stereo_df2T_instance_f32 *S,
+      float32_t *pSrc,
+      float32_t *pDst,
+      uint32_t blockSize);
 
   /**
    * @brief Processing function for the floating-point transposed direct form II Biquad cascade filter.
@@ -3650,11 +3472,10 @@ void arm_rfft_fast_f32(
    * @param[in]  blockSize  number of samples to process.
    */
   void arm_biquad_cascade_df2T_f64(
-  const arm_biquad_cascade_df2T_instance_f64 * S,
-  float64_t * pSrc,
-  float64_t * pDst,
-  uint32_t blockSize);
-
+      const arm_biquad_cascade_df2T_instance_f64 *S,
+      float64_t *pSrc,
+      float64_t *pDst,
+      uint32_t blockSize);
 
   /**
    * @brief  Initialization function for the floating-point transposed direct form II Biquad cascade filter.
@@ -3664,11 +3485,10 @@ void arm_rfft_fast_f32(
    * @param[in]     pState     points to the state buffer.
    */
   void arm_biquad_cascade_df2T_init_f32(
-  arm_biquad_cascade_df2T_instance_f32 * S,
-  uint8_t numStages,
-  float32_t * pCoeffs,
-  float32_t * pState);
-
+      arm_biquad_cascade_df2T_instance_f32 *S,
+      uint8_t numStages,
+      float32_t *pCoeffs,
+      float32_t *pState);
 
   /**
    * @brief  Initialization function for the floating-point transposed direct form II Biquad cascade filter.
@@ -3678,11 +3498,10 @@ void arm_rfft_fast_f32(
    * @param[in]     pState     points to the state buffer.
    */
   void arm_biquad_cascade_stereo_df2T_init_f32(
-  arm_biquad_cascade_stereo_df2T_instance_f32 * S,
-  uint8_t numStages,
-  float32_t * pCoeffs,
-  float32_t * pState);
-
+      arm_biquad_cascade_stereo_df2T_instance_f32 *S,
+      uint8_t numStages,
+      float32_t *pCoeffs,
+      float32_t *pState);
 
   /**
    * @brief  Initialization function for the floating-point transposed direct form II Biquad cascade filter.
@@ -3692,20 +3511,19 @@ void arm_rfft_fast_f32(
    * @param[in]     pState     points to the state buffer.
    */
   void arm_biquad_cascade_df2T_init_f64(
-  arm_biquad_cascade_df2T_instance_f64 * S,
-  uint8_t numStages,
-  float64_t * pCoeffs,
-  float64_t * pState);
-
+      arm_biquad_cascade_df2T_instance_f64 *S,
+      uint8_t numStages,
+      float64_t *pCoeffs,
+      float64_t *pState);
 
   /**
    * @brief Instance structure for the Q15 FIR lattice filter.
    */
   typedef struct
   {
-    uint16_t numStages;                  /**< number of filter stages. */
-    q15_t *pState;                       /**< points to the state variable array. The array is of length numStages. */
-    q15_t *pCoeffs;                      /**< points to the coefficient array. The array is of length numStages. */
+    uint16_t numStages; /**< number of filter stages. */
+    q15_t *pState;      /**< points to the state variable array. The array is of length numStages. */
+    q15_t *pCoeffs;     /**< points to the coefficient array. The array is of length numStages. */
   } arm_fir_lattice_instance_q15;
 
   /**
@@ -3713,9 +3531,9 @@ void arm_rfft_fast_f32(
    */
   typedef struct
   {
-    uint16_t numStages;                  /**< number of filter stages. */
-    q31_t *pState;                       /**< points to the state variable array. The array is of length numStages. */
-    q31_t *pCoeffs;                      /**< points to the coefficient array. The array is of length numStages. */
+    uint16_t numStages; /**< number of filter stages. */
+    q31_t *pState;      /**< points to the state variable array. The array is of length numStages. */
+    q31_t *pCoeffs;     /**< points to the coefficient array. The array is of length numStages. */
   } arm_fir_lattice_instance_q31;
 
   /**
@@ -3723,11 +3541,10 @@ void arm_rfft_fast_f32(
    */
   typedef struct
   {
-    uint16_t numStages;                  /**< number of filter stages. */
-    float32_t *pState;                   /**< points to the state variable array. The array is of length numStages. */
-    float32_t *pCoeffs;                  /**< points to the coefficient array. The array is of length numStages. */
+    uint16_t numStages; /**< number of filter stages. */
+    float32_t *pState;  /**< points to the state variable array. The array is of length numStages. */
+    float32_t *pCoeffs; /**< points to the coefficient array. The array is of length numStages. */
   } arm_fir_lattice_instance_f32;
-
 
   /**
    * @brief Initialization function for the Q15 FIR lattice filter.
@@ -3737,11 +3554,10 @@ void arm_rfft_fast_f32(
    * @param[in] pState     points to the state buffer.  The array is of length numStages.
    */
   void arm_fir_lattice_init_q15(
-  arm_fir_lattice_instance_q15 * S,
-  uint16_t numStages,
-  q15_t * pCoeffs,
-  q15_t * pState);
-
+      arm_fir_lattice_instance_q15 *S,
+      uint16_t numStages,
+      q15_t *pCoeffs,
+      q15_t *pState);
 
   /**
    * @brief Processing function for the Q15 FIR lattice filter.
@@ -3751,11 +3567,10 @@ void arm_rfft_fast_f32(
    * @param[in]  blockSize  number of samples to process.
    */
   void arm_fir_lattice_q15(
-  const arm_fir_lattice_instance_q15 * S,
-  q15_t * pSrc,
-  q15_t * pDst,
-  uint32_t blockSize);
-
+      const arm_fir_lattice_instance_q15 *S,
+      q15_t *pSrc,
+      q15_t *pDst,
+      uint32_t blockSize);
 
   /**
    * @brief Initialization function for the Q31 FIR lattice filter.
@@ -3765,11 +3580,10 @@ void arm_rfft_fast_f32(
    * @param[in] pState     points to the state buffer.   The array is of length numStages.
    */
   void arm_fir_lattice_init_q31(
-  arm_fir_lattice_instance_q31 * S,
-  uint16_t numStages,
-  q31_t * pCoeffs,
-  q31_t * pState);
-
+      arm_fir_lattice_instance_q31 *S,
+      uint16_t numStages,
+      q31_t *pCoeffs,
+      q31_t *pState);
 
   /**
    * @brief Processing function for the Q31 FIR lattice filter.
@@ -3779,13 +3593,12 @@ void arm_rfft_fast_f32(
    * @param[in]  blockSize  number of samples to process.
    */
   void arm_fir_lattice_q31(
-  const arm_fir_lattice_instance_q31 * S,
-  q31_t * pSrc,
-  q31_t * pDst,
-  uint32_t blockSize);
+      const arm_fir_lattice_instance_q31 *S,
+      q31_t *pSrc,
+      q31_t *pDst,
+      uint32_t blockSize);
 
-
-/**
+  /**
  * @brief Initialization function for the floating-point FIR lattice filter.
  * @param[in] S          points to an instance of the floating-point FIR lattice structure.
  * @param[in] numStages  number of filter stages.
@@ -3793,11 +3606,10 @@ void arm_rfft_fast_f32(
  * @param[in] pState     points to the state buffer.  The array is of length numStages.
  */
   void arm_fir_lattice_init_f32(
-  arm_fir_lattice_instance_f32 * S,
-  uint16_t numStages,
-  float32_t * pCoeffs,
-  float32_t * pState);
-
+      arm_fir_lattice_instance_f32 *S,
+      uint16_t numStages,
+      float32_t *pCoeffs,
+      float32_t *pState);
 
   /**
    * @brief Processing function for the floating-point FIR lattice filter.
@@ -3807,21 +3619,20 @@ void arm_rfft_fast_f32(
    * @param[in]  blockSize  number of samples to process.
    */
   void arm_fir_lattice_f32(
-  const arm_fir_lattice_instance_f32 * S,
-  float32_t * pSrc,
-  float32_t * pDst,
-  uint32_t blockSize);
-
+      const arm_fir_lattice_instance_f32 *S,
+      float32_t *pSrc,
+      float32_t *pDst,
+      uint32_t blockSize);
 
   /**
    * @brief Instance structure for the Q15 IIR lattice filter.
    */
   typedef struct
   {
-    uint16_t numStages;                  /**< number of stages in the filter. */
-    q15_t *pState;                       /**< points to the state variable array. The array is of length numStages+blockSize. */
-    q15_t *pkCoeffs;                     /**< points to the reflection coefficient array. The array is of length numStages. */
-    q15_t *pvCoeffs;                     /**< points to the ladder coefficient array. The array is of length numStages+1. */
+    uint16_t numStages; /**< number of stages in the filter. */
+    q15_t *pState;      /**< points to the state variable array. The array is of length numStages+blockSize. */
+    q15_t *pkCoeffs;    /**< points to the reflection coefficient array. The array is of length numStages. */
+    q15_t *pvCoeffs;    /**< points to the ladder coefficient array. The array is of length numStages+1. */
   } arm_iir_lattice_instance_q15;
 
   /**
@@ -3829,10 +3640,10 @@ void arm_rfft_fast_f32(
    */
   typedef struct
   {
-    uint16_t numStages;                  /**< number of stages in the filter. */
-    q31_t *pState;                       /**< points to the state variable array. The array is of length numStages+blockSize. */
-    q31_t *pkCoeffs;                     /**< points to the reflection coefficient array. The array is of length numStages. */
-    q31_t *pvCoeffs;                     /**< points to the ladder coefficient array. The array is of length numStages+1. */
+    uint16_t numStages; /**< number of stages in the filter. */
+    q31_t *pState;      /**< points to the state variable array. The array is of length numStages+blockSize. */
+    q31_t *pkCoeffs;    /**< points to the reflection coefficient array. The array is of length numStages. */
+    q31_t *pvCoeffs;    /**< points to the ladder coefficient array. The array is of length numStages+1. */
   } arm_iir_lattice_instance_q31;
 
   /**
@@ -3840,12 +3651,11 @@ void arm_rfft_fast_f32(
    */
   typedef struct
   {
-    uint16_t numStages;                  /**< number of stages in the filter. */
-    float32_t *pState;                   /**< points to the state variable array. The array is of length numStages+blockSize. */
-    float32_t *pkCoeffs;                 /**< points to the reflection coefficient array. The array is of length numStages. */
-    float32_t *pvCoeffs;                 /**< points to the ladder coefficient array. The array is of length numStages+1. */
+    uint16_t numStages;  /**< number of stages in the filter. */
+    float32_t *pState;   /**< points to the state variable array. The array is of length numStages+blockSize. */
+    float32_t *pkCoeffs; /**< points to the reflection coefficient array. The array is of length numStages. */
+    float32_t *pvCoeffs; /**< points to the ladder coefficient array. The array is of length numStages+1. */
   } arm_iir_lattice_instance_f32;
-
 
   /**
    * @brief Processing function for the floating-point IIR lattice filter.
@@ -3855,11 +3665,10 @@ void arm_rfft_fast_f32(
    * @param[in]  blockSize  number of samples to process.
    */
   void arm_iir_lattice_f32(
-  const arm_iir_lattice_instance_f32 * S,
-  float32_t * pSrc,
-  float32_t * pDst,
-  uint32_t blockSize);
-
+      const arm_iir_lattice_instance_f32 *S,
+      float32_t *pSrc,
+      float32_t *pDst,
+      uint32_t blockSize);
 
   /**
    * @brief Initialization function for the floating-point IIR lattice filter.
@@ -3871,13 +3680,12 @@ void arm_rfft_fast_f32(
    * @param[in] blockSize  number of samples to process.
    */
   void arm_iir_lattice_init_f32(
-  arm_iir_lattice_instance_f32 * S,
-  uint16_t numStages,
-  float32_t * pkCoeffs,
-  float32_t * pvCoeffs,
-  float32_t * pState,
-  uint32_t blockSize);
-
+      arm_iir_lattice_instance_f32 *S,
+      uint16_t numStages,
+      float32_t *pkCoeffs,
+      float32_t *pvCoeffs,
+      float32_t *pState,
+      uint32_t blockSize);
 
   /**
    * @brief Processing function for the Q31 IIR lattice filter.
@@ -3887,11 +3695,10 @@ void arm_rfft_fast_f32(
    * @param[in]  blockSize  number of samples to process.
    */
   void arm_iir_lattice_q31(
-  const arm_iir_lattice_instance_q31 * S,
-  q31_t * pSrc,
-  q31_t * pDst,
-  uint32_t blockSize);
-
+      const arm_iir_lattice_instance_q31 *S,
+      q31_t *pSrc,
+      q31_t *pDst,
+      uint32_t blockSize);
 
   /**
    * @brief Initialization function for the Q31 IIR lattice filter.
@@ -3903,13 +3710,12 @@ void arm_rfft_fast_f32(
    * @param[in] blockSize  number of samples to process.
    */
   void arm_iir_lattice_init_q31(
-  arm_iir_lattice_instance_q31 * S,
-  uint16_t numStages,
-  q31_t * pkCoeffs,
-  q31_t * pvCoeffs,
-  q31_t * pState,
-  uint32_t blockSize);
-
+      arm_iir_lattice_instance_q31 *S,
+      uint16_t numStages,
+      q31_t *pkCoeffs,
+      q31_t *pvCoeffs,
+      q31_t *pState,
+      uint32_t blockSize);
 
   /**
    * @brief Processing function for the Q15 IIR lattice filter.
@@ -3919,13 +3725,12 @@ void arm_rfft_fast_f32(
    * @param[in]  blockSize  number of samples to process.
    */
   void arm_iir_lattice_q15(
-  const arm_iir_lattice_instance_q15 * S,
-  q15_t * pSrc,
-  q15_t * pDst,
-  uint32_t blockSize);
+      const arm_iir_lattice_instance_q15 *S,
+      q15_t *pSrc,
+      q15_t *pDst,
+      uint32_t blockSize);
 
-
-/**
+  /**
  * @brief Initialization function for the Q15 IIR lattice filter.
  * @param[in] S          points to an instance of the fixed-point Q15 IIR lattice structure.
  * @param[in] numStages  number of stages in the filter.
@@ -3935,25 +3740,23 @@ void arm_rfft_fast_f32(
  * @param[in] blockSize  number of samples to process per call.
  */
   void arm_iir_lattice_init_q15(
-  arm_iir_lattice_instance_q15 * S,
-  uint16_t numStages,
-  q15_t * pkCoeffs,
-  q15_t * pvCoeffs,
-  q15_t * pState,
-  uint32_t blockSize);
-
+      arm_iir_lattice_instance_q15 *S,
+      uint16_t numStages,
+      q15_t *pkCoeffs,
+      q15_t *pvCoeffs,
+      q15_t *pState,
+      uint32_t blockSize);
 
   /**
    * @brief Instance structure for the floating-point LMS filter.
    */
   typedef struct
   {
-    uint16_t numTaps;    /**< number of coefficients in the filter. */
-    float32_t *pState;   /**< points to the state variable array. The array is of length numTaps+blockSize-1. */
-    float32_t *pCoeffs;  /**< points to the coefficient array. The array is of length numTaps. */
-    float32_t mu;        /**< step size that controls filter coefficient updates. */
+    uint16_t numTaps;   /**< number of coefficients in the filter. */
+    float32_t *pState;  /**< points to the state variable array. The array is of length numTaps+blockSize-1. */
+    float32_t *pCoeffs; /**< points to the coefficient array. The array is of length numTaps. */
+    float32_t mu;       /**< step size that controls filter coefficient updates. */
   } arm_lms_instance_f32;
-
 
   /**
    * @brief Processing function for floating-point LMS filter.
@@ -3965,13 +3768,12 @@ void arm_rfft_fast_f32(
    * @param[in]  blockSize  number of samples to process.
    */
   void arm_lms_f32(
-  const arm_lms_instance_f32 * S,
-  float32_t * pSrc,
-  float32_t * pRef,
-  float32_t * pOut,
-  float32_t * pErr,
-  uint32_t blockSize);
-
+      const arm_lms_instance_f32 *S,
+      float32_t *pSrc,
+      float32_t *pRef,
+      float32_t *pOut,
+      float32_t *pErr,
+      uint32_t blockSize);
 
   /**
    * @brief Initialization function for floating-point LMS filter.
@@ -3983,26 +3785,24 @@ void arm_rfft_fast_f32(
    * @param[in] blockSize  number of samples to process.
    */
   void arm_lms_init_f32(
-  arm_lms_instance_f32 * S,
-  uint16_t numTaps,
-  float32_t * pCoeffs,
-  float32_t * pState,
-  float32_t mu,
-  uint32_t blockSize);
-
+      arm_lms_instance_f32 *S,
+      uint16_t numTaps,
+      float32_t *pCoeffs,
+      float32_t *pState,
+      float32_t mu,
+      uint32_t blockSize);
 
   /**
    * @brief Instance structure for the Q15 LMS filter.
    */
   typedef struct
   {
-    uint16_t numTaps;    /**< number of coefficients in the filter. */
-    q15_t *pState;       /**< points to the state variable array. The array is of length numTaps+blockSize-1. */
-    q15_t *pCoeffs;      /**< points to the coefficient array. The array is of length numTaps. */
-    q15_t mu;            /**< step size that controls filter coefficient updates. */
-    uint32_t postShift;  /**< bit shift applied to coefficients. */
+    uint16_t numTaps;   /**< number of coefficients in the filter. */
+    q15_t *pState;      /**< points to the state variable array. The array is of length numTaps+blockSize-1. */
+    q15_t *pCoeffs;     /**< points to the coefficient array. The array is of length numTaps. */
+    q15_t mu;           /**< step size that controls filter coefficient updates. */
+    uint32_t postShift; /**< bit shift applied to coefficients. */
   } arm_lms_instance_q15;
-
 
   /**
    * @brief Initialization function for the Q15 LMS filter.
@@ -4015,14 +3815,13 @@ void arm_rfft_fast_f32(
    * @param[in] postShift  bit shift applied to coefficients.
    */
   void arm_lms_init_q15(
-  arm_lms_instance_q15 * S,
-  uint16_t numTaps,
-  q15_t * pCoeffs,
-  q15_t * pState,
-  q15_t mu,
-  uint32_t blockSize,
-  uint32_t postShift);
-
+      arm_lms_instance_q15 *S,
+      uint16_t numTaps,
+      q15_t *pCoeffs,
+      q15_t *pState,
+      q15_t mu,
+      uint32_t blockSize,
+      uint32_t postShift);
 
   /**
    * @brief Processing function for Q15 LMS filter.
@@ -4034,26 +3833,24 @@ void arm_rfft_fast_f32(
    * @param[in]  blockSize  number of samples to process.
    */
   void arm_lms_q15(
-  const arm_lms_instance_q15 * S,
-  q15_t * pSrc,
-  q15_t * pRef,
-  q15_t * pOut,
-  q15_t * pErr,
-  uint32_t blockSize);
-
+      const arm_lms_instance_q15 *S,
+      q15_t *pSrc,
+      q15_t *pRef,
+      q15_t *pOut,
+      q15_t *pErr,
+      uint32_t blockSize);
 
   /**
    * @brief Instance structure for the Q31 LMS filter.
    */
   typedef struct
   {
-    uint16_t numTaps;    /**< number of coefficients in the filter. */
-    q31_t *pState;       /**< points to the state variable array. The array is of length numTaps+blockSize-1. */
-    q31_t *pCoeffs;      /**< points to the coefficient array. The array is of length numTaps. */
-    q31_t mu;            /**< step size that controls filter coefficient updates. */
-    uint32_t postShift;  /**< bit shift applied to coefficients. */
+    uint16_t numTaps;   /**< number of coefficients in the filter. */
+    q31_t *pState;      /**< points to the state variable array. The array is of length numTaps+blockSize-1. */
+    q31_t *pCoeffs;     /**< points to the coefficient array. The array is of length numTaps. */
+    q31_t mu;           /**< step size that controls filter coefficient updates. */
+    uint32_t postShift; /**< bit shift applied to coefficients. */
   } arm_lms_instance_q31;
-
 
   /**
    * @brief Processing function for Q31 LMS filter.
@@ -4065,13 +3862,12 @@ void arm_rfft_fast_f32(
    * @param[in]  blockSize  number of samples to process.
    */
   void arm_lms_q31(
-  const arm_lms_instance_q31 * S,
-  q31_t * pSrc,
-  q31_t * pRef,
-  q31_t * pOut,
-  q31_t * pErr,
-  uint32_t blockSize);
-
+      const arm_lms_instance_q31 *S,
+      q31_t *pSrc,
+      q31_t *pRef,
+      q31_t *pOut,
+      q31_t *pErr,
+      uint32_t blockSize);
 
   /**
    * @brief Initialization function for Q31 LMS filter.
@@ -4084,28 +3880,26 @@ void arm_rfft_fast_f32(
    * @param[in] postShift  bit shift applied to coefficients.
    */
   void arm_lms_init_q31(
-  arm_lms_instance_q31 * S,
-  uint16_t numTaps,
-  q31_t * pCoeffs,
-  q31_t * pState,
-  q31_t mu,
-  uint32_t blockSize,
-  uint32_t postShift);
-
+      arm_lms_instance_q31 *S,
+      uint16_t numTaps,
+      q31_t *pCoeffs,
+      q31_t *pState,
+      q31_t mu,
+      uint32_t blockSize,
+      uint32_t postShift);
 
   /**
    * @brief Instance structure for the floating-point normalized LMS filter.
    */
   typedef struct
   {
-    uint16_t numTaps;     /**< number of coefficients in the filter. */
-    float32_t *pState;    /**< points to the state variable array. The array is of length numTaps+blockSize-1. */
-    float32_t *pCoeffs;   /**< points to the coefficient array. The array is of length numTaps. */
-    float32_t mu;         /**< step size that control filter coefficient updates. */
-    float32_t energy;     /**< saves previous frame energy. */
-    float32_t x0;         /**< saves previous input sample. */
+    uint16_t numTaps;   /**< number of coefficients in the filter. */
+    float32_t *pState;  /**< points to the state variable array. The array is of length numTaps+blockSize-1. */
+    float32_t *pCoeffs; /**< points to the coefficient array. The array is of length numTaps. */
+    float32_t mu;       /**< step size that control filter coefficient updates. */
+    float32_t energy;   /**< saves previous frame energy. */
+    float32_t x0;       /**< saves previous input sample. */
   } arm_lms_norm_instance_f32;
-
 
   /**
    * @brief Processing function for floating-point normalized LMS filter.
@@ -4117,13 +3911,12 @@ void arm_rfft_fast_f32(
    * @param[in]  blockSize  number of samples to process.
    */
   void arm_lms_norm_f32(
-  arm_lms_norm_instance_f32 * S,
-  float32_t * pSrc,
-  float32_t * pRef,
-  float32_t * pOut,
-  float32_t * pErr,
-  uint32_t blockSize);
-
+      arm_lms_norm_instance_f32 *S,
+      float32_t *pSrc,
+      float32_t *pRef,
+      float32_t *pOut,
+      float32_t *pErr,
+      uint32_t blockSize);
 
   /**
    * @brief Initialization function for floating-point normalized LMS filter.
@@ -4135,29 +3928,27 @@ void arm_rfft_fast_f32(
    * @param[in] blockSize  number of samples to process.
    */
   void arm_lms_norm_init_f32(
-  arm_lms_norm_instance_f32 * S,
-  uint16_t numTaps,
-  float32_t * pCoeffs,
-  float32_t * pState,
-  float32_t mu,
-  uint32_t blockSize);
-
+      arm_lms_norm_instance_f32 *S,
+      uint16_t numTaps,
+      float32_t *pCoeffs,
+      float32_t *pState,
+      float32_t mu,
+      uint32_t blockSize);
 
   /**
    * @brief Instance structure for the Q31 normalized LMS filter.
    */
   typedef struct
   {
-    uint16_t numTaps;     /**< number of coefficients in the filter. */
-    q31_t *pState;        /**< points to the state variable array. The array is of length numTaps+blockSize-1. */
-    q31_t *pCoeffs;       /**< points to the coefficient array. The array is of length numTaps. */
-    q31_t mu;             /**< step size that controls filter coefficient updates. */
-    uint8_t postShift;    /**< bit shift applied to coefficients. */
-    q31_t *recipTable;    /**< points to the reciprocal initial value table. */
-    q31_t energy;         /**< saves previous frame energy. */
-    q31_t x0;             /**< saves previous input sample. */
+    uint16_t numTaps;  /**< number of coefficients in the filter. */
+    q31_t *pState;     /**< points to the state variable array. The array is of length numTaps+blockSize-1. */
+    q31_t *pCoeffs;    /**< points to the coefficient array. The array is of length numTaps. */
+    q31_t mu;          /**< step size that controls filter coefficient updates. */
+    uint8_t postShift; /**< bit shift applied to coefficients. */
+    q31_t *recipTable; /**< points to the reciprocal initial value table. */
+    q31_t energy;      /**< saves previous frame energy. */
+    q31_t x0;          /**< saves previous input sample. */
   } arm_lms_norm_instance_q31;
-
 
   /**
    * @brief Processing function for Q31 normalized LMS filter.
@@ -4169,13 +3960,12 @@ void arm_rfft_fast_f32(
    * @param[in]  blockSize  number of samples to process.
    */
   void arm_lms_norm_q31(
-  arm_lms_norm_instance_q31 * S,
-  q31_t * pSrc,
-  q31_t * pRef,
-  q31_t * pOut,
-  q31_t * pErr,
-  uint32_t blockSize);
-
+      arm_lms_norm_instance_q31 *S,
+      q31_t *pSrc,
+      q31_t *pRef,
+      q31_t *pOut,
+      q31_t *pErr,
+      uint32_t blockSize);
 
   /**
    * @brief Initialization function for Q31 normalized LMS filter.
@@ -4188,30 +3978,28 @@ void arm_rfft_fast_f32(
    * @param[in] postShift  bit shift applied to coefficients.
    */
   void arm_lms_norm_init_q31(
-  arm_lms_norm_instance_q31 * S,
-  uint16_t numTaps,
-  q31_t * pCoeffs,
-  q31_t * pState,
-  q31_t mu,
-  uint32_t blockSize,
-  uint8_t postShift);
-
+      arm_lms_norm_instance_q31 *S,
+      uint16_t numTaps,
+      q31_t *pCoeffs,
+      q31_t *pState,
+      q31_t mu,
+      uint32_t blockSize,
+      uint8_t postShift);
 
   /**
    * @brief Instance structure for the Q15 normalized LMS filter.
    */
   typedef struct
   {
-    uint16_t numTaps;     /**< Number of coefficients in the filter. */
-    q15_t *pState;        /**< points to the state variable array. The array is of length numTaps+blockSize-1. */
-    q15_t *pCoeffs;       /**< points to the coefficient array. The array is of length numTaps. */
-    q15_t mu;             /**< step size that controls filter coefficient updates. */
-    uint8_t postShift;    /**< bit shift applied to coefficients. */
-    q15_t *recipTable;    /**< Points to the reciprocal initial value table. */
-    q15_t energy;         /**< saves previous frame energy. */
-    q15_t x0;             /**< saves previous input sample. */
+    uint16_t numTaps;  /**< Number of coefficients in the filter. */
+    q15_t *pState;     /**< points to the state variable array. The array is of length numTaps+blockSize-1. */
+    q15_t *pCoeffs;    /**< points to the coefficient array. The array is of length numTaps. */
+    q15_t mu;          /**< step size that controls filter coefficient updates. */
+    uint8_t postShift; /**< bit shift applied to coefficients. */
+    q15_t *recipTable; /**< Points to the reciprocal initial value table. */
+    q15_t energy;      /**< saves previous frame energy. */
+    q15_t x0;          /**< saves previous input sample. */
   } arm_lms_norm_instance_q15;
-
 
   /**
    * @brief Processing function for Q15 normalized LMS filter.
@@ -4223,13 +4011,12 @@ void arm_rfft_fast_f32(
    * @param[in]  blockSize  number of samples to process.
    */
   void arm_lms_norm_q15(
-  arm_lms_norm_instance_q15 * S,
-  q15_t * pSrc,
-  q15_t * pRef,
-  q15_t * pOut,
-  q15_t * pErr,
-  uint32_t blockSize);
-
+      arm_lms_norm_instance_q15 *S,
+      q15_t *pSrc,
+      q15_t *pRef,
+      q15_t *pOut,
+      q15_t *pErr,
+      uint32_t blockSize);
 
   /**
    * @brief Initialization function for Q15 normalized LMS filter.
@@ -4242,14 +4029,13 @@ void arm_rfft_fast_f32(
    * @param[in] postShift  bit shift applied to coefficients.
    */
   void arm_lms_norm_init_q15(
-  arm_lms_norm_instance_q15 * S,
-  uint16_t numTaps,
-  q15_t * pCoeffs,
-  q15_t * pState,
-  q15_t mu,
-  uint32_t blockSize,
-  uint8_t postShift);
-
+      arm_lms_norm_instance_q15 *S,
+      uint16_t numTaps,
+      q15_t *pCoeffs,
+      q15_t *pState,
+      q15_t mu,
+      uint32_t blockSize,
+      uint8_t postShift);
 
   /**
    * @brief Correlation of floating-point sequences.
@@ -4260,14 +4046,13 @@ void arm_rfft_fast_f32(
    * @param[out] pDst     points to the block of output data  Length 2 * max(srcALen, srcBLen) - 1.
    */
   void arm_correlate_f32(
-  float32_t * pSrcA,
-  uint32_t srcALen,
-  float32_t * pSrcB,
-  uint32_t srcBLen,
-  float32_t * pDst);
+      float32_t *pSrcA,
+      uint32_t srcALen,
+      float32_t *pSrcB,
+      uint32_t srcBLen,
+      float32_t *pDst);
 
-
-   /**
+  /**
    * @brief Correlation of Q15 sequences
    * @param[in]  pSrcA     points to the first input sequence.
    * @param[in]  srcALen   length of the first input sequence.
@@ -4277,13 +4062,12 @@ void arm_rfft_fast_f32(
    * @param[in]  pScratch  points to scratch buffer of size max(srcALen, srcBLen) + 2*min(srcALen, srcBLen) - 2.
    */
   void arm_correlate_opt_q15(
-  q15_t * pSrcA,
-  uint32_t srcALen,
-  q15_t * pSrcB,
-  uint32_t srcBLen,
-  q15_t * pDst,
-  q15_t * pScratch);
-
+      q15_t *pSrcA,
+      uint32_t srcALen,
+      q15_t *pSrcB,
+      uint32_t srcBLen,
+      q15_t *pDst,
+      q15_t *pScratch);
 
   /**
    * @brief Correlation of Q15 sequences.
@@ -4295,12 +4079,11 @@ void arm_rfft_fast_f32(
    */
 
   void arm_correlate_q15(
-  q15_t * pSrcA,
-  uint32_t srcALen,
-  q15_t * pSrcB,
-  uint32_t srcBLen,
-  q15_t * pDst);
-
+      q15_t *pSrcA,
+      uint32_t srcALen,
+      q15_t *pSrcB,
+      uint32_t srcBLen,
+      q15_t *pDst);
 
   /**
    * @brief Correlation of Q15 sequences (fast version) for Cortex-M3 and Cortex-M4.
@@ -4312,12 +4095,11 @@ void arm_rfft_fast_f32(
    */
 
   void arm_correlate_fast_q15(
-  q15_t * pSrcA,
-  uint32_t srcALen,
-  q15_t * pSrcB,
-  uint32_t srcBLen,
-  q15_t * pDst);
-
+      q15_t *pSrcA,
+      uint32_t srcALen,
+      q15_t *pSrcB,
+      uint32_t srcBLen,
+      q15_t *pDst);
 
   /**
    * @brief Correlation of Q15 sequences (fast version) for Cortex-M3 and Cortex-M4.
@@ -4329,13 +4111,12 @@ void arm_rfft_fast_f32(
    * @param[in]  pScratch  points to scratch buffer of size max(srcALen, srcBLen) + 2*min(srcALen, srcBLen) - 2.
    */
   void arm_correlate_fast_opt_q15(
-  q15_t * pSrcA,
-  uint32_t srcALen,
-  q15_t * pSrcB,
-  uint32_t srcBLen,
-  q15_t * pDst,
-  q15_t * pScratch);
-
+      q15_t *pSrcA,
+      uint32_t srcALen,
+      q15_t *pSrcB,
+      uint32_t srcBLen,
+      q15_t *pDst,
+      q15_t *pScratch);
 
   /**
    * @brief Correlation of Q31 sequences.
@@ -4346,12 +4127,11 @@ void arm_rfft_fast_f32(
    * @param[out] pDst     points to the block of output data  Length 2 * max(srcALen, srcBLen) - 1.
    */
   void arm_correlate_q31(
-  q31_t * pSrcA,
-  uint32_t srcALen,
-  q31_t * pSrcB,
-  uint32_t srcBLen,
-  q31_t * pDst);
-
+      q31_t *pSrcA,
+      uint32_t srcALen,
+      q31_t *pSrcB,
+      uint32_t srcBLen,
+      q31_t *pDst);
 
   /**
    * @brief Correlation of Q31 sequences (fast version) for Cortex-M3 and Cortex-M4
@@ -4362,14 +4142,13 @@ void arm_rfft_fast_f32(
    * @param[out] pDst     points to the block of output data  Length 2 * max(srcALen, srcBLen) - 1.
    */
   void arm_correlate_fast_q31(
-  q31_t * pSrcA,
-  uint32_t srcALen,
-  q31_t * pSrcB,
-  uint32_t srcBLen,
-  q31_t * pDst);
+      q31_t *pSrcA,
+      uint32_t srcALen,
+      q31_t *pSrcB,
+      uint32_t srcBLen,
+      q31_t *pDst);
 
-
- /**
+  /**
    * @brief Correlation of Q7 sequences.
    * @param[in]  pSrcA      points to the first input sequence.
    * @param[in]  srcALen    length of the first input sequence.
@@ -4380,14 +4159,13 @@ void arm_rfft_fast_f32(
    * @param[in]  pScratch2  points to scratch buffer (of type q15_t) of size min(srcALen, srcBLen).
    */
   void arm_correlate_opt_q7(
-  q7_t * pSrcA,
-  uint32_t srcALen,
-  q7_t * pSrcB,
-  uint32_t srcBLen,
-  q7_t * pDst,
-  q15_t * pScratch1,
-  q15_t * pScratch2);
-
+      q7_t *pSrcA,
+      uint32_t srcALen,
+      q7_t *pSrcB,
+      uint32_t srcBLen,
+      q7_t *pDst,
+      q15_t *pScratch1,
+      q15_t *pScratch2);
 
   /**
    * @brief Correlation of Q7 sequences.
@@ -4398,24 +4176,23 @@ void arm_rfft_fast_f32(
    * @param[out] pDst     points to the block of output data  Length 2 * max(srcALen, srcBLen) - 1.
    */
   void arm_correlate_q7(
-  q7_t * pSrcA,
-  uint32_t srcALen,
-  q7_t * pSrcB,
-  uint32_t srcBLen,
-  q7_t * pDst);
-
+      q7_t *pSrcA,
+      uint32_t srcALen,
+      q7_t *pSrcB,
+      uint32_t srcBLen,
+      q7_t *pDst);
 
   /**
    * @brief Instance structure for the floating-point sparse FIR filter.
    */
   typedef struct
   {
-    uint16_t numTaps;             /**< number of coefficients in the filter. */
-    uint16_t stateIndex;          /**< state buffer index.  Points to the oldest sample in the state buffer. */
-    float32_t *pState;            /**< points to the state buffer array. The array is of length maxDelay+blockSize-1. */
-    float32_t *pCoeffs;           /**< points to the coefficient array. The array is of length numTaps.*/
-    uint16_t maxDelay;            /**< maximum offset specified by the pTapDelay array. */
-    int32_t *pTapDelay;           /**< points to the array of delay values.  The array is of length numTaps. */
+    uint16_t numTaps;    /**< number of coefficients in the filter. */
+    uint16_t stateIndex; /**< state buffer index.  Points to the oldest sample in the state buffer. */
+    float32_t *pState;   /**< points to the state buffer array. The array is of length maxDelay+blockSize-1. */
+    float32_t *pCoeffs;  /**< points to the coefficient array. The array is of length numTaps.*/
+    uint16_t maxDelay;   /**< maximum offset specified by the pTapDelay array. */
+    int32_t *pTapDelay;  /**< points to the array of delay values.  The array is of length numTaps. */
   } arm_fir_sparse_instance_f32;
 
   /**
@@ -4423,12 +4200,12 @@ void arm_rfft_fast_f32(
    */
   typedef struct
   {
-    uint16_t numTaps;             /**< number of coefficients in the filter. */
-    uint16_t stateIndex;          /**< state buffer index.  Points to the oldest sample in the state buffer. */
-    q31_t *pState;                /**< points to the state buffer array. The array is of length maxDelay+blockSize-1. */
-    q31_t *pCoeffs;               /**< points to the coefficient array. The array is of length numTaps.*/
-    uint16_t maxDelay;            /**< maximum offset specified by the pTapDelay array. */
-    int32_t *pTapDelay;           /**< points to the array of delay values.  The array is of length numTaps. */
+    uint16_t numTaps;    /**< number of coefficients in the filter. */
+    uint16_t stateIndex; /**< state buffer index.  Points to the oldest sample in the state buffer. */
+    q31_t *pState;       /**< points to the state buffer array. The array is of length maxDelay+blockSize-1. */
+    q31_t *pCoeffs;      /**< points to the coefficient array. The array is of length numTaps.*/
+    uint16_t maxDelay;   /**< maximum offset specified by the pTapDelay array. */
+    int32_t *pTapDelay;  /**< points to the array of delay values.  The array is of length numTaps. */
   } arm_fir_sparse_instance_q31;
 
   /**
@@ -4436,12 +4213,12 @@ void arm_rfft_fast_f32(
    */
   typedef struct
   {
-    uint16_t numTaps;             /**< number of coefficients in the filter. */
-    uint16_t stateIndex;          /**< state buffer index.  Points to the oldest sample in the state buffer. */
-    q15_t *pState;                /**< points to the state buffer array. The array is of length maxDelay+blockSize-1. */
-    q15_t *pCoeffs;               /**< points to the coefficient array. The array is of length numTaps.*/
-    uint16_t maxDelay;            /**< maximum offset specified by the pTapDelay array. */
-    int32_t *pTapDelay;           /**< points to the array of delay values.  The array is of length numTaps. */
+    uint16_t numTaps;    /**< number of coefficients in the filter. */
+    uint16_t stateIndex; /**< state buffer index.  Points to the oldest sample in the state buffer. */
+    q15_t *pState;       /**< points to the state buffer array. The array is of length maxDelay+blockSize-1. */
+    q15_t *pCoeffs;      /**< points to the coefficient array. The array is of length numTaps.*/
+    uint16_t maxDelay;   /**< maximum offset specified by the pTapDelay array. */
+    int32_t *pTapDelay;  /**< points to the array of delay values.  The array is of length numTaps. */
   } arm_fir_sparse_instance_q15;
 
   /**
@@ -4449,14 +4226,13 @@ void arm_rfft_fast_f32(
    */
   typedef struct
   {
-    uint16_t numTaps;             /**< number of coefficients in the filter. */
-    uint16_t stateIndex;          /**< state buffer index.  Points to the oldest sample in the state buffer. */
-    q7_t *pState;                 /**< points to the state buffer array. The array is of length maxDelay+blockSize-1. */
-    q7_t *pCoeffs;                /**< points to the coefficient array. The array is of length numTaps.*/
-    uint16_t maxDelay;            /**< maximum offset specified by the pTapDelay array. */
-    int32_t *pTapDelay;           /**< points to the array of delay values.  The array is of length numTaps. */
+    uint16_t numTaps;    /**< number of coefficients in the filter. */
+    uint16_t stateIndex; /**< state buffer index.  Points to the oldest sample in the state buffer. */
+    q7_t *pState;        /**< points to the state buffer array. The array is of length maxDelay+blockSize-1. */
+    q7_t *pCoeffs;       /**< points to the coefficient array. The array is of length numTaps.*/
+    uint16_t maxDelay;   /**< maximum offset specified by the pTapDelay array. */
+    int32_t *pTapDelay;  /**< points to the array of delay values.  The array is of length numTaps. */
   } arm_fir_sparse_instance_q7;
-
 
   /**
    * @brief Processing function for the floating-point sparse FIR filter.
@@ -4467,12 +4243,11 @@ void arm_rfft_fast_f32(
    * @param[in]  blockSize   number of input samples to process per call.
    */
   void arm_fir_sparse_f32(
-  arm_fir_sparse_instance_f32 * S,
-  float32_t * pSrc,
-  float32_t * pDst,
-  float32_t * pScratchIn,
-  uint32_t blockSize);
-
+      arm_fir_sparse_instance_f32 *S,
+      float32_t *pSrc,
+      float32_t *pDst,
+      float32_t *pScratchIn,
+      uint32_t blockSize);
 
   /**
    * @brief  Initialization function for the floating-point sparse FIR filter.
@@ -4485,14 +4260,13 @@ void arm_rfft_fast_f32(
    * @param[in]     blockSize  number of samples that will be processed per block.
    */
   void arm_fir_sparse_init_f32(
-  arm_fir_sparse_instance_f32 * S,
-  uint16_t numTaps,
-  float32_t * pCoeffs,
-  float32_t * pState,
-  int32_t * pTapDelay,
-  uint16_t maxDelay,
-  uint32_t blockSize);
-
+      arm_fir_sparse_instance_f32 *S,
+      uint16_t numTaps,
+      float32_t *pCoeffs,
+      float32_t *pState,
+      int32_t *pTapDelay,
+      uint16_t maxDelay,
+      uint32_t blockSize);
 
   /**
    * @brief Processing function for the Q31 sparse FIR filter.
@@ -4503,12 +4277,11 @@ void arm_rfft_fast_f32(
    * @param[in]  blockSize   number of input samples to process per call.
    */
   void arm_fir_sparse_q31(
-  arm_fir_sparse_instance_q31 * S,
-  q31_t * pSrc,
-  q31_t * pDst,
-  q31_t * pScratchIn,
-  uint32_t blockSize);
-
+      arm_fir_sparse_instance_q31 *S,
+      q31_t *pSrc,
+      q31_t *pDst,
+      q31_t *pScratchIn,
+      uint32_t blockSize);
 
   /**
    * @brief  Initialization function for the Q31 sparse FIR filter.
@@ -4521,14 +4294,13 @@ void arm_rfft_fast_f32(
    * @param[in]     blockSize  number of samples that will be processed per block.
    */
   void arm_fir_sparse_init_q31(
-  arm_fir_sparse_instance_q31 * S,
-  uint16_t numTaps,
-  q31_t * pCoeffs,
-  q31_t * pState,
-  int32_t * pTapDelay,
-  uint16_t maxDelay,
-  uint32_t blockSize);
-
+      arm_fir_sparse_instance_q31 *S,
+      uint16_t numTaps,
+      q31_t *pCoeffs,
+      q31_t *pState,
+      int32_t *pTapDelay,
+      uint16_t maxDelay,
+      uint32_t blockSize);
 
   /**
    * @brief Processing function for the Q15 sparse FIR filter.
@@ -4540,13 +4312,12 @@ void arm_rfft_fast_f32(
    * @param[in]  blockSize    number of input samples to process per call.
    */
   void arm_fir_sparse_q15(
-  arm_fir_sparse_instance_q15 * S,
-  q15_t * pSrc,
-  q15_t * pDst,
-  q15_t * pScratchIn,
-  q31_t * pScratchOut,
-  uint32_t blockSize);
-
+      arm_fir_sparse_instance_q15 *S,
+      q15_t *pSrc,
+      q15_t *pDst,
+      q15_t *pScratchIn,
+      q31_t *pScratchOut,
+      uint32_t blockSize);
 
   /**
    * @brief  Initialization function for the Q15 sparse FIR filter.
@@ -4559,14 +4330,13 @@ void arm_rfft_fast_f32(
    * @param[in]     blockSize  number of samples that will be processed per block.
    */
   void arm_fir_sparse_init_q15(
-  arm_fir_sparse_instance_q15 * S,
-  uint16_t numTaps,
-  q15_t * pCoeffs,
-  q15_t * pState,
-  int32_t * pTapDelay,
-  uint16_t maxDelay,
-  uint32_t blockSize);
-
+      arm_fir_sparse_instance_q15 *S,
+      uint16_t numTaps,
+      q15_t *pCoeffs,
+      q15_t *pState,
+      int32_t *pTapDelay,
+      uint16_t maxDelay,
+      uint32_t blockSize);
 
   /**
    * @brief Processing function for the Q7 sparse FIR filter.
@@ -4578,13 +4348,12 @@ void arm_rfft_fast_f32(
    * @param[in]  blockSize    number of input samples to process per call.
    */
   void arm_fir_sparse_q7(
-  arm_fir_sparse_instance_q7 * S,
-  q7_t * pSrc,
-  q7_t * pDst,
-  q7_t * pScratchIn,
-  q31_t * pScratchOut,
-  uint32_t blockSize);
-
+      arm_fir_sparse_instance_q7 *S,
+      q7_t *pSrc,
+      q7_t *pDst,
+      q7_t *pScratchIn,
+      q31_t *pScratchOut,
+      uint32_t blockSize);
 
   /**
    * @brief  Initialization function for the Q7 sparse FIR filter.
@@ -4597,14 +4366,13 @@ void arm_rfft_fast_f32(
    * @param[in]     blockSize  number of samples that will be processed per block.
    */
   void arm_fir_sparse_init_q7(
-  arm_fir_sparse_instance_q7 * S,
-  uint16_t numTaps,
-  q7_t * pCoeffs,
-  q7_t * pState,
-  int32_t * pTapDelay,
-  uint16_t maxDelay,
-  uint32_t blockSize);
-
+      arm_fir_sparse_instance_q7 *S,
+      uint16_t numTaps,
+      q7_t *pCoeffs,
+      q7_t *pState,
+      int32_t *pTapDelay,
+      uint16_t maxDelay,
+      uint32_t blockSize);
 
   /**
    * @brief  Floating-point sin_cos function.
@@ -4613,10 +4381,9 @@ void arm_rfft_fast_f32(
    * @param[out] pCosVal  points to the processed cos output.
    */
   void arm_sin_cos_f32(
-  float32_t theta,
-  float32_t * pSinVal,
-  float32_t * pCosVal);
-
+      float32_t theta,
+      float32_t *pSinVal,
+      float32_t *pCosVal);
 
   /**
    * @brief  Q31 sin_cos function.
@@ -4625,10 +4392,9 @@ void arm_rfft_fast_f32(
    * @param[out] pCosVal  points to the processed cosine output.
    */
   void arm_sin_cos_q31(
-  q31_t theta,
-  q31_t * pSinVal,
-  q31_t * pCosVal);
-
+      q31_t theta,
+      q31_t *pSinVal,
+      q31_t *pCosVal);
 
   /**
    * @brief  Floating-point complex conjugate.
@@ -4637,9 +4403,9 @@ void arm_rfft_fast_f32(
    * @param[in]  numSamples  number of complex samples in each vector
    */
   void arm_cmplx_conj_f32(
-  float32_t * pSrc,
-  float32_t * pDst,
-  uint32_t numSamples);
+      float32_t *pSrc,
+      float32_t *pDst,
+      uint32_t numSamples);
 
   /**
    * @brief  Q31 complex conjugate.
@@ -4648,10 +4414,9 @@ void arm_rfft_fast_f32(
    * @param[in]  numSamples  number of complex samples in each vector
    */
   void arm_cmplx_conj_q31(
-  q31_t * pSrc,
-  q31_t * pDst,
-  uint32_t numSamples);
-
+      q31_t *pSrc,
+      q31_t *pDst,
+      uint32_t numSamples);
 
   /**
    * @brief  Q15 complex conjugate.
@@ -4660,10 +4425,9 @@ void arm_rfft_fast_f32(
    * @param[in]  numSamples  number of complex samples in each vector
    */
   void arm_cmplx_conj_q15(
-  q15_t * pSrc,
-  q15_t * pDst,
-  uint32_t numSamples);
-
+      q15_t *pSrc,
+      q15_t *pDst,
+      uint32_t numSamples);
 
   /**
    * @brief  Floating-point complex magnitude squared
@@ -4672,10 +4436,9 @@ void arm_rfft_fast_f32(
    * @param[in]  numSamples  number of complex samples in the input vector
    */
   void arm_cmplx_mag_squared_f32(
-  float32_t * pSrc,
-  float32_t * pDst,
-  uint32_t numSamples);
-
+      float32_t *pSrc,
+      float32_t *pDst,
+      uint32_t numSamples);
 
   /**
    * @brief  Q31 complex magnitude squared
@@ -4684,10 +4447,9 @@ void arm_rfft_fast_f32(
    * @param[in]  numSamples  number of complex samples in the input vector
    */
   void arm_cmplx_mag_squared_q31(
-  q31_t * pSrc,
-  q31_t * pDst,
-  uint32_t numSamples);
-
+      q31_t *pSrc,
+      q31_t *pDst,
+      uint32_t numSamples);
 
   /**
    * @brief  Q15 complex magnitude squared
@@ -4696,12 +4458,11 @@ void arm_rfft_fast_f32(
    * @param[in]  numSamples  number of complex samples in the input vector
    */
   void arm_cmplx_mag_squared_q15(
-  q15_t * pSrc,
-  q15_t * pDst,
-  uint32_t numSamples);
+      q15_t *pSrc,
+      q15_t *pDst,
+      uint32_t numSamples);
 
-
- /**
+  /**
    * @ingroup groupController
    */
 
@@ -4774,14 +4535,14 @@ void arm_rfft_fast_f32(
    * @return out processed output sample.
    */
   CMSIS_INLINE __STATIC_INLINE float32_t arm_pid_f32(
-  arm_pid_instance_f32 * S,
-  float32_t in)
+      arm_pid_instance_f32 *S,
+      float32_t in)
   {
     float32_t out;
 
     /* y[n] = y[n-1] + A0 * x[n] + A1 * x[n-1] + A2 * x[n-2]  */
     out = (S->A0 * in) +
-      (S->A1 * S->state[0]) + (S->A2 * S->state[1]) + (S->state[2]);
+          (S->A1 * S->state[0]) + (S->A2 * S->state[1]) + (S->state[2]);
 
     /* Update state */
     S->state[1] = S->state[0];
@@ -4790,7 +4551,6 @@ void arm_rfft_fast_f32(
 
     /* return to application */
     return (out);
-
   }
 
   /**
@@ -4808,23 +4568,23 @@ void arm_rfft_fast_f32(
    * After all multiply-accumulates are performed, the 2.62 accumulator is truncated to 1.32 format and then saturated to 1.31 format.
    */
   CMSIS_INLINE __STATIC_INLINE q31_t arm_pid_q31(
-  arm_pid_instance_q31 * S,
-  q31_t in)
+      arm_pid_instance_q31 *S,
+      q31_t in)
   {
     q63_t acc;
     q31_t out;
 
     /* acc = A0 * x[n]  */
-    acc = (q63_t) S->A0 * in;
+    acc = (q63_t)S->A0 * in;
 
     /* acc += A1 * x[n-1] */
-    acc += (q63_t) S->A1 * S->state[0];
+    acc += (q63_t)S->A1 * S->state[0];
 
     /* acc += A2 * x[n-2]  */
-    acc += (q63_t) S->A2 * S->state[1];
+    acc += (q63_t)S->A2 * S->state[1];
 
     /* convert output to 1.31 format to add y[n-1] */
-    out = (q31_t) (acc >> 31U);
+    out = (q31_t)(acc >> 31U);
 
     /* out += y[n-1] */
     out += S->state[2];
@@ -4837,7 +4597,6 @@ void arm_rfft_fast_f32(
     /* return to application */
     return (out);
   }
-
 
   /**
    * @brief  Process function for the Q15 PID Control.
@@ -4855,37 +4614,37 @@ void arm_rfft_fast_f32(
    * Lastly, the accumulator is saturated to yield a result in 1.15 format.
    */
   CMSIS_INLINE __STATIC_INLINE q15_t arm_pid_q15(
-  arm_pid_instance_q15 * S,
-  q15_t in)
+      arm_pid_instance_q15 *S,
+      q15_t in)
   {
     q63_t acc;
     q15_t out;
 
-#if defined (ARM_MATH_DSP)
+#if defined(ARM_MATH_DSP)
     __SIMD32_TYPE *vstate;
 
     /* Implementation of PID controller */
 
     /* acc = A0 * x[n]  */
-    acc = (q31_t) __SMUAD((uint32_t)S->A0, (uint32_t)in);
+    acc = (q31_t)__SMUAD((uint32_t)S->A0, (uint32_t)in);
 
     /* acc += A1 * x[n-1] + A2 * x[n-2]  */
     vstate = __SIMD32_CONST(S->state);
     acc = (q63_t)__SMLALD((uint32_t)S->A1, (uint32_t)*vstate, (uint64_t)acc);
 #else
-    /* acc = A0 * x[n]  */
-    acc = ((q31_t) S->A0) * in;
+  /* acc = A0 * x[n]  */
+  acc = ((q31_t)S->A0) * in;
 
-    /* acc += A1 * x[n-1] + A2 * x[n-2]  */
-    acc += (q31_t) S->A1 * S->state[0];
-    acc += (q31_t) S->A2 * S->state[1];
+  /* acc += A1 * x[n-1] + A2 * x[n-2]  */
+  acc += (q31_t)S->A1 * S->state[0];
+  acc += (q31_t)S->A2 * S->state[1];
 #endif
 
     /* acc += y[n-1] */
-    acc += (q31_t) S->state[2] << 15;
+    acc += (q31_t)S->state[2] << 15;
 
     /* saturate the output */
-    out = (q15_t) (__SSAT((acc >> 15), 16));
+    out = (q15_t)(__SSAT((acc >> 15), 16));
 
     /* Update state */
     S->state[1] = S->state[0];
@@ -4900,7 +4659,6 @@ void arm_rfft_fast_f32(
    * @} end of PID group
    */
 
-
   /**
    * @brief Floating-point matrix inverse.
    * @param[in]  src   points to the instance of the input floating-point matrix structure.
@@ -4909,9 +4667,8 @@ void arm_rfft_fast_f32(
    * If the input matrix is singular (does not have an inverse), then the algorithm terminates and returns error status ARM_MATH_SINGULAR.
    */
   arm_status arm_mat_inverse_f32(
-  const arm_matrix_instance_f32 * src,
-  arm_matrix_instance_f32 * dst);
-
+      const arm_matrix_instance_f32 *src,
+      arm_matrix_instance_f32 *dst);
 
   /**
    * @brief Floating-point matrix inverse.
@@ -4921,10 +4678,8 @@ void arm_rfft_fast_f32(
    * If the input matrix is singular (does not have an inverse), then the algorithm terminates and returns error status ARM_MATH_SINGULAR.
    */
   arm_status arm_mat_inverse_f64(
-  const arm_matrix_instance_f64 * src,
-  arm_matrix_instance_f64 * dst);
-
-
+      const arm_matrix_instance_f64 *src,
+      arm_matrix_instance_f64 *dst);
 
   /**
    * @ingroup groupController
@@ -4966,18 +4721,17 @@ void arm_rfft_fast_f32(
    * @param[out] pIbeta   points to output two-phase orthogonal vector axis beta
    */
   CMSIS_INLINE __STATIC_INLINE void arm_clarke_f32(
-  float32_t Ia,
-  float32_t Ib,
-  float32_t * pIalpha,
-  float32_t * pIbeta)
+      float32_t Ia,
+      float32_t Ib,
+      float32_t *pIalpha,
+      float32_t *pIbeta)
   {
     /* Calculate pIalpha using the equation, pIalpha = Ia */
     *pIalpha = Ia;
 
     /* Calculate pIbeta using the equation, pIbeta = (1/sqrt(3)) * Ia + (2/sqrt(3)) * Ib */
-    *pIbeta = ((float32_t) 0.57735026919 * Ia + (float32_t) 1.15470053838 * Ib);
+    *pIbeta = ((float32_t)0.57735026919 * Ia + (float32_t)1.15470053838 * Ib);
   }
-
 
   /**
    * @brief  Clarke transform for Q31 version
@@ -4993,21 +4747,21 @@ void arm_rfft_fast_f32(
    * There is saturation on the addition, hence there is no risk of overflow.
    */
   CMSIS_INLINE __STATIC_INLINE void arm_clarke_q31(
-  q31_t Ia,
-  q31_t Ib,
-  q31_t * pIalpha,
-  q31_t * pIbeta)
+      q31_t Ia,
+      q31_t Ib,
+      q31_t *pIalpha,
+      q31_t *pIbeta)
   {
-    q31_t product1, product2;                    /* Temporary variables used to store intermediate results */
+    q31_t product1, product2; /* Temporary variables used to store intermediate results */
 
     /* Calculating pIalpha from Ia by equation pIalpha = Ia */
     *pIalpha = Ia;
 
     /* Intermediate product is calculated by (1/(sqrt(3)) * Ia) */
-    product1 = (q31_t) (((q63_t) Ia * 0x24F34E8B) >> 30);
+    product1 = (q31_t)(((q63_t)Ia * 0x24F34E8B) >> 30);
 
     /* Intermediate product is calculated by (2/sqrt(3) * Ib) */
-    product2 = (q31_t) (((q63_t) Ib * 0x49E69D16) >> 30);
+    product2 = (q31_t)(((q63_t)Ib * 0x49E69D16) >> 30);
 
     /* pIbeta is calculated by adding the intermediate products */
     *pIbeta = __QADD(product1, product2);
@@ -5024,11 +4778,9 @@ void arm_rfft_fast_f32(
    * @param[in]  blockSize  number of samples to process
    */
   void arm_q7_to_q31(
-  q7_t * pSrc,
-  q31_t * pDst,
-  uint32_t blockSize);
-
-
+      q7_t *pSrc,
+      q31_t *pDst,
+      uint32_t blockSize);
 
   /**
    * @ingroup groupController
@@ -5055,7 +4807,7 @@ void arm_rfft_fast_f32(
    * @{
    */
 
-   /**
+  /**
    * @brief  Floating-point Inverse Clarke transform
    * @param[in]  Ialpha  input two-phase orthogonal vector axis alpha
    * @param[in]  Ibeta   input two-phase orthogonal vector axis beta
@@ -5063,10 +4815,10 @@ void arm_rfft_fast_f32(
    * @param[out] pIb     points to output three-phase coordinate <code>b</code>
    */
   CMSIS_INLINE __STATIC_INLINE void arm_inv_clarke_f32(
-  float32_t Ialpha,
-  float32_t Ibeta,
-  float32_t * pIa,
-  float32_t * pIb)
+      float32_t Ialpha,
+      float32_t Ibeta,
+      float32_t *pIa,
+      float32_t *pIb)
   {
     /* Calculating pIa from Ialpha by equation pIa = Ialpha */
     *pIa = Ialpha;
@@ -5074,7 +4826,6 @@ void arm_rfft_fast_f32(
     /* Calculating pIb from Ialpha and Ibeta by equation pIb = -(1/2) * Ialpha + (sqrt(3)/2) * Ibeta */
     *pIb = -0.5f * Ialpha + 0.8660254039f * Ibeta;
   }
-
 
   /**
    * @brief  Inverse Clarke transform for Q31 version
@@ -5090,21 +4841,21 @@ void arm_rfft_fast_f32(
    * There is saturation on the subtraction, hence there is no risk of overflow.
    */
   CMSIS_INLINE __STATIC_INLINE void arm_inv_clarke_q31(
-  q31_t Ialpha,
-  q31_t Ibeta,
-  q31_t * pIa,
-  q31_t * pIb)
+      q31_t Ialpha,
+      q31_t Ibeta,
+      q31_t *pIa,
+      q31_t *pIb)
   {
-    q31_t product1, product2;                    /* Temporary variables used to store intermediate results */
+    q31_t product1, product2; /* Temporary variables used to store intermediate results */
 
     /* Calculating pIa from Ialpha by equation pIa = Ialpha */
     *pIa = Ialpha;
 
     /* Intermediate product is calculated by (1/(2*sqrt(3)) * Ia) */
-    product1 = (q31_t) (((q63_t) (Ialpha) * (0x40000000)) >> 31);
+    product1 = (q31_t)(((q63_t)(Ialpha) * (0x40000000)) >> 31);
 
     /* Intermediate product is calculated by (1/sqrt(3) * pIb) */
-    product2 = (q31_t) (((q63_t) (Ibeta) * (0x6ED9EBA1)) >> 31);
+    product2 = (q31_t)(((q63_t)(Ibeta) * (0x6ED9EBA1)) >> 31);
 
     /* pIb is calculated by subtracting the products */
     *pIb = __QSUB(product2, product1);
@@ -5121,11 +4872,9 @@ void arm_rfft_fast_f32(
    * @param[in]  blockSize  number of samples to process
    */
   void arm_q7_to_q15(
-  q7_t * pSrc,
-  q15_t * pDst,
-  uint32_t blockSize);
-
-
+      q7_t *pSrc,
+      q15_t *pDst,
+      uint32_t blockSize);
 
   /**
    * @ingroup groupController
@@ -5173,12 +4922,12 @@ void arm_rfft_fast_f32(
    *
    */
   CMSIS_INLINE __STATIC_INLINE void arm_park_f32(
-  float32_t Ialpha,
-  float32_t Ibeta,
-  float32_t * pId,
-  float32_t * pIq,
-  float32_t sinVal,
-  float32_t cosVal)
+      float32_t Ialpha,
+      float32_t Ibeta,
+      float32_t *pId,
+      float32_t *pIq,
+      float32_t sinVal,
+      float32_t cosVal)
   {
     /* Calculate pId using the equation, pId = Ialpha * cosVal + Ibeta * sinVal */
     *pId = Ialpha * cosVal + Ibeta * sinVal;
@@ -5186,7 +4935,6 @@ void arm_rfft_fast_f32(
     /* Calculate pIq using the equation, pIq = - Ialpha * sinVal + Ibeta * cosVal */
     *pIq = -Ialpha * sinVal + Ibeta * cosVal;
   }
-
 
   /**
    * @brief  Park transform for Q31 version
@@ -5204,28 +4952,27 @@ void arm_rfft_fast_f32(
    * There is saturation on the addition and subtraction, hence there is no risk of overflow.
    */
   CMSIS_INLINE __STATIC_INLINE void arm_park_q31(
-  q31_t Ialpha,
-  q31_t Ibeta,
-  q31_t * pId,
-  q31_t * pIq,
-  q31_t sinVal,
-  q31_t cosVal)
+      q31_t Ialpha,
+      q31_t Ibeta,
+      q31_t *pId,
+      q31_t *pIq,
+      q31_t sinVal,
+      q31_t cosVal)
   {
-    q31_t product1, product2;                    /* Temporary variables used to store intermediate results */
-    q31_t product3, product4;                    /* Temporary variables used to store intermediate results */
+    q31_t product1, product2; /* Temporary variables used to store intermediate results */
+    q31_t product3, product4; /* Temporary variables used to store intermediate results */
 
     /* Intermediate product is calculated by (Ialpha * cosVal) */
-    product1 = (q31_t) (((q63_t) (Ialpha) * (cosVal)) >> 31);
+    product1 = (q31_t)(((q63_t)(Ialpha) * (cosVal)) >> 31);
 
     /* Intermediate product is calculated by (Ibeta * sinVal) */
-    product2 = (q31_t) (((q63_t) (Ibeta) * (sinVal)) >> 31);
-
+    product2 = (q31_t)(((q63_t)(Ibeta) * (sinVal)) >> 31);
 
     /* Intermediate product is calculated by (Ialpha * sinVal) */
-    product3 = (q31_t) (((q63_t) (Ialpha) * (sinVal)) >> 31);
+    product3 = (q31_t)(((q63_t)(Ialpha) * (sinVal)) >> 31);
 
     /* Intermediate product is calculated by (Ibeta * cosVal) */
-    product4 = (q31_t) (((q63_t) (Ibeta) * (cosVal)) >> 31);
+    product4 = (q31_t)(((q63_t)(Ibeta) * (cosVal)) >> 31);
 
     /* Calculate pId by adding the two intermediate products 1 and 2 */
     *pId = __QADD(product1, product2);
@@ -5245,10 +4992,9 @@ void arm_rfft_fast_f32(
    * @param[in]  blockSize  is the number of samples to process
    */
   void arm_q7_to_float(
-  q7_t * pSrc,
-  float32_t * pDst,
-  uint32_t blockSize);
-
+      q7_t *pSrc,
+      float32_t *pDst,
+      uint32_t blockSize);
 
   /**
    * @ingroup groupController
@@ -5276,7 +5022,7 @@ void arm_rfft_fast_f32(
    * @{
    */
 
-   /**
+  /**
    * @brief  Floating-point Inverse Park transform
    * @param[in]  Id       input coordinate of rotor reference frame d
    * @param[in]  Iq       input coordinate of rotor reference frame q
@@ -5286,12 +5032,12 @@ void arm_rfft_fast_f32(
    * @param[in]  cosVal   cosine value of rotation angle theta
    */
   CMSIS_INLINE __STATIC_INLINE void arm_inv_park_f32(
-  float32_t Id,
-  float32_t Iq,
-  float32_t * pIalpha,
-  float32_t * pIbeta,
-  float32_t sinVal,
-  float32_t cosVal)
+      float32_t Id,
+      float32_t Iq,
+      float32_t *pIalpha,
+      float32_t *pIbeta,
+      float32_t sinVal,
+      float32_t cosVal)
   {
     /* Calculate pIalpha using the equation, pIalpha = Id * cosVal - Iq * sinVal */
     *pIalpha = Id * cosVal - Iq * sinVal;
@@ -5299,7 +5045,6 @@ void arm_rfft_fast_f32(
     /* Calculate pIbeta using the equation, pIbeta = Id * sinVal + Iq * cosVal */
     *pIbeta = Id * sinVal + Iq * cosVal;
   }
-
 
   /**
    * @brief  Inverse Park transform for   Q31 version
@@ -5317,28 +5062,27 @@ void arm_rfft_fast_f32(
    * There is saturation on the addition, hence there is no risk of overflow.
    */
   CMSIS_INLINE __STATIC_INLINE void arm_inv_park_q31(
-  q31_t Id,
-  q31_t Iq,
-  q31_t * pIalpha,
-  q31_t * pIbeta,
-  q31_t sinVal,
-  q31_t cosVal)
+      q31_t Id,
+      q31_t Iq,
+      q31_t *pIalpha,
+      q31_t *pIbeta,
+      q31_t sinVal,
+      q31_t cosVal)
   {
-    q31_t product1, product2;                    /* Temporary variables used to store intermediate results */
-    q31_t product3, product4;                    /* Temporary variables used to store intermediate results */
+    q31_t product1, product2; /* Temporary variables used to store intermediate results */
+    q31_t product3, product4; /* Temporary variables used to store intermediate results */
 
     /* Intermediate product is calculated by (Id * cosVal) */
-    product1 = (q31_t) (((q63_t) (Id) * (cosVal)) >> 31);
+    product1 = (q31_t)(((q63_t)(Id) * (cosVal)) >> 31);
 
     /* Intermediate product is calculated by (Iq * sinVal) */
-    product2 = (q31_t) (((q63_t) (Iq) * (sinVal)) >> 31);
-
+    product2 = (q31_t)(((q63_t)(Iq) * (sinVal)) >> 31);
 
     /* Intermediate product is calculated by (Id * sinVal) */
-    product3 = (q31_t) (((q63_t) (Id) * (sinVal)) >> 31);
+    product3 = (q31_t)(((q63_t)(Id) * (sinVal)) >> 31);
 
     /* Intermediate product is calculated by (Iq * cosVal) */
-    product4 = (q31_t) (((q63_t) (Iq) * (cosVal)) >> 31);
+    product4 = (q31_t)(((q63_t)(Iq) * (cosVal)) >> 31);
 
     /* Calculate pIalpha by using the two intermediate products 1 and 2 */
     *pIalpha = __QSUB(product1, product2);
@@ -5351,7 +5095,6 @@ void arm_rfft_fast_f32(
    * @} end of Inverse park group
    */
 
-
   /**
    * @brief  Converts the elements of the Q31 vector to floating-point vector.
    * @param[in]  pSrc       is input pointer
@@ -5359,9 +5102,9 @@ void arm_rfft_fast_f32(
    * @param[in]  blockSize  is the number of samples to process
    */
   void arm_q31_to_float(
-  q31_t * pSrc,
-  float32_t * pDst,
-  uint32_t blockSize);
+      q31_t *pSrc,
+      float32_t *pDst,
+      uint32_t blockSize);
 
   /**
    * @ingroup groupInterpolation
@@ -5412,18 +5155,18 @@ void arm_rfft_fast_f32(
    *
    */
   CMSIS_INLINE __STATIC_INLINE float32_t arm_linear_interp_f32(
-  arm_linear_interp_instance_f32 * S,
-  float32_t x)
+      arm_linear_interp_instance_f32 *S,
+      float32_t x)
   {
     float32_t y;
-    float32_t x0, x1;                            /* Nearest input values */
-    float32_t y0, y1;                            /* Nearest output values */
-    float32_t xSpacing = S->xSpacing;            /* spacing between input values */
-    int32_t i;                                   /* Index variable */
-    float32_t *pYData = S->pYData;               /* pointer to output table */
+    float32_t x0, x1;                 /* Nearest input values */
+    float32_t y0, y1;                 /* Nearest output values */
+    float32_t xSpacing = S->xSpacing; /* spacing between input values */
+    int32_t i;                        /* Index variable */
+    float32_t *pYData = S->pYData;    /* pointer to output table */
 
     /* Calculation of index */
-    i = (int32_t) ((x - S->x1) / xSpacing);
+    i = (int32_t)((x - S->x1) / xSpacing);
 
     if (i < 0)
     {
@@ -5438,7 +5181,7 @@ void arm_rfft_fast_f32(
     else
     {
       /* Calculation of nearest input values */
-      x0 = S->x1 +  i      * xSpacing;
+      x0 = S->x1 + i * xSpacing;
       x1 = S->x1 + (i + 1) * xSpacing;
 
       /* Read of nearest output values */
@@ -5447,15 +5190,13 @@ void arm_rfft_fast_f32(
 
       /* Calculation of output */
       y = y0 + (x - x0) * ((y1 - y0) / (x1 - x0));
-
     }
 
     /* returns output value */
     return (y);
   }
 
-
-   /**
+  /**
    *
    * @brief  Process function for the Q31 Linear Interpolation Function.
    * @param[in] pYData   pointer to Q31 Linear Interpolation table
@@ -5469,14 +5210,14 @@ void arm_rfft_fast_f32(
    *
    */
   CMSIS_INLINE __STATIC_INLINE q31_t arm_linear_interp_q31(
-  q31_t * pYData,
-  q31_t x,
-  uint32_t nValues)
+      q31_t *pYData,
+      q31_t x,
+      uint32_t nValues)
   {
-    q31_t y;                                     /* output */
-    q31_t y0, y1;                                /* Nearest output values */
-    q31_t fract;                                 /* fractional part */
-    int32_t index;                               /* Index to read nearest output values */
+    q31_t y;       /* output */
+    q31_t y0, y1;  /* Nearest output values */
+    q31_t fract;   /* fractional part */
+    int32_t index; /* Index to read nearest output values */
 
     /* Input is in 12.20 format */
     /* 12 bits for the table index */
@@ -5502,16 +5243,15 @@ void arm_rfft_fast_f32(
       y1 = pYData[index + 1];
 
       /* Calculation of y0 * (1-fract) and y is in 2.30 format */
-      y = ((q31_t) ((q63_t) y0 * (0x7FFFFFFF - fract) >> 32));
+      y = ((q31_t)((q63_t)y0 * (0x7FFFFFFF - fract) >> 32));
 
       /* Calculation of y0 * (1-fract) + y1 *fract and y is in 2.30 format */
-      y += ((q31_t) (((q63_t) y1 * fract) >> 32));
+      y += ((q31_t)(((q63_t)y1 * fract) >> 32));
 
       /* Convert y to 1.31 format */
       return (y << 1U);
     }
   }
-
 
   /**
    *
@@ -5527,14 +5267,14 @@ void arm_rfft_fast_f32(
    *
    */
   CMSIS_INLINE __STATIC_INLINE q15_t arm_linear_interp_q15(
-  q15_t * pYData,
-  q31_t x,
-  uint32_t nValues)
+      q15_t *pYData,
+      q31_t x,
+      uint32_t nValues)
   {
-    q63_t y;                                     /* output */
-    q15_t y0, y1;                                /* Nearest output values */
-    q31_t fract;                                 /* fractional part */
-    int32_t index;                               /* Index to read nearest output values */
+    q63_t y;       /* output */
+    q15_t y0, y1;  /* Nearest output values */
+    q31_t fract;   /* fractional part */
+    int32_t index; /* Index to read nearest output values */
 
     /* Input is in 12.20 format */
     /* 12 bits for the table index */
@@ -5560,16 +5300,15 @@ void arm_rfft_fast_f32(
       y1 = pYData[index + 1];
 
       /* Calculation of y0 * (1-fract) and y is in 13.35 format */
-      y = ((q63_t) y0 * (0xFFFFF - fract));
+      y = ((q63_t)y0 * (0xFFFFF - fract));
 
       /* Calculation of (y0 * (1-fract) + y1 * fract) and y is in 13.35 format */
-      y += ((q63_t) y1 * (fract));
+      y += ((q63_t)y1 * (fract));
 
       /* convert y to 1.15 format */
-      return (q15_t) (y >> 20);
+      return (q15_t)(y >> 20);
     }
   }
-
 
   /**
    *
@@ -5584,14 +5323,14 @@ void arm_rfft_fast_f32(
    * This function can support maximum of table size 2^12.
    */
   CMSIS_INLINE __STATIC_INLINE q7_t arm_linear_interp_q7(
-  q7_t * pYData,
-  q31_t x,
-  uint32_t nValues)
+      q7_t *pYData,
+      q31_t x,
+      uint32_t nValues)
   {
-    q31_t y;                                     /* output */
-    q7_t y0, y1;                                 /* Nearest output values */
-    q31_t fract;                                 /* fractional part */
-    uint32_t index;                              /* Index to read nearest output values */
+    q31_t y;        /* output */
+    q7_t y0, y1;    /* Nearest output values */
+    q31_t fract;    /* fractional part */
+    uint32_t index; /* Index to read nearest output values */
 
     /* Input is in 12.20 format */
     /* 12 bits for the table index */
@@ -5623,8 +5362,8 @@ void arm_rfft_fast_f32(
       y += (y1 * fract);
 
       /* convert y to 1.7(q7) format */
-      return (q7_t) (y >> 20);
-     }
+      return (q7_t)(y >> 20);
+    }
   }
 
   /**
@@ -5637,8 +5376,7 @@ void arm_rfft_fast_f32(
    * @return  sin(x).
    */
   float32_t arm_sin_f32(
-  float32_t x);
-
+      float32_t x);
 
   /**
    * @brief  Fast approximation to the trigonometric sine function for Q31 data.
@@ -5646,8 +5384,7 @@ void arm_rfft_fast_f32(
    * @return  sin(x).
    */
   q31_t arm_sin_q31(
-  q31_t x);
-
+      q31_t x);
 
   /**
    * @brief  Fast approximation to the trigonometric sine function for Q15 data.
@@ -5655,8 +5392,7 @@ void arm_rfft_fast_f32(
    * @return  sin(x).
    */
   q15_t arm_sin_q15(
-  q15_t x);
-
+      q15_t x);
 
   /**
    * @brief  Fast approximation to the trigonometric cosine function for floating-point data.
@@ -5664,8 +5400,7 @@ void arm_rfft_fast_f32(
    * @return  cos(x).
    */
   float32_t arm_cos_f32(
-  float32_t x);
-
+      float32_t x);
 
   /**
    * @brief Fast approximation to the trigonometric cosine function for Q31 data.
@@ -5673,8 +5408,7 @@ void arm_rfft_fast_f32(
    * @return  cos(x).
    */
   q31_t arm_cos_q31(
-  q31_t x);
-
+      q31_t x);
 
   /**
    * @brief  Fast approximation to the trigonometric cosine function for Q15 data.
@@ -5682,13 +5416,11 @@ void arm_rfft_fast_f32(
    * @return  cos(x).
    */
   q15_t arm_cos_q15(
-  q15_t x);
-
+      q15_t x);
 
   /**
    * @ingroup groupFastMath
    */
-
 
   /**
    * @defgroup SQRT Square Root
@@ -5710,7 +5442,6 @@ void arm_rfft_fast_f32(
    * </pre>
    */
 
-
   /**
    * @addtogroup SQRT
    * @{
@@ -5724,22 +5455,24 @@ void arm_rfft_fast_f32(
    * <code>in</code> is negative value and returns zero output for negative values.
    */
   CMSIS_INLINE __STATIC_INLINE arm_status arm_sqrt_f32(
-  float32_t in,
-  float32_t * pOut)
+      float32_t in,
+      float32_t *pOut)
   {
     if (in >= 0.0f)
     {
 
-#if   (__FPU_USED == 1) && defined ( __CC_ARM   )
+#if (__FPU_USED == 1) && defined(__CC_ARM)
       *pOut = __sqrtf(in);
 #elif (__FPU_USED == 1) && (defined(__ARMCC_VERSION) && (__ARMCC_VERSION >= 6010050))
-      *pOut = __builtin_sqrtf(in);
+    *pOut = __builtin_sqrtf(in);
 #elif (__FPU_USED == 1) && defined(__GNUC__)
-      *pOut = __builtin_sqrtf(in);
-#elif (__FPU_USED == 1) && defined ( __ICCARM__ ) && (__VER__ >= 6040000)
-      __ASM("VSQRT.F32 %0,%1" : "=t"(*pOut) : "t"(in));
+    *pOut = __builtin_sqrtf(in);
+#elif (__FPU_USED == 1) && defined(__ICCARM__) && (__VER__ >= 6040000)
+    __ASM("VSQRT.F32 %0,%1"
+          : "=t"(*pOut)
+          : "t"(in));
 #else
-      *pOut = sqrtf(in);
+    *pOut = sqrtf(in);
 #endif
 
       return (ARM_MATH_SUCCESS);
@@ -5751,7 +5484,6 @@ void arm_rfft_fast_f32(
     }
   }
 
-
   /**
    * @brief Q31 square root function.
    * @param[in]  in    input value.  The range of the input value is [0 +1) or 0x00000000 to 0x7FFFFFFF.
@@ -5760,9 +5492,8 @@ void arm_rfft_fast_f32(
    * <code>in</code> is negative value and returns zero output for negative values.
    */
   arm_status arm_sqrt_q31(
-  q31_t in,
-  q31_t * pOut);
-
+      q31_t in,
+      q31_t *pOut);
 
   /**
    * @brief  Q15 square root function.
@@ -5772,25 +5503,24 @@ void arm_rfft_fast_f32(
    * <code>in</code> is negative value and returns zero output for negative values.
    */
   arm_status arm_sqrt_q15(
-  q15_t in,
-  q15_t * pOut);
+      q15_t in,
+      q15_t *pOut);
 
   /**
    * @} end of SQRT group
    */
 
-
   /**
    * @brief floating-point Circular write function.
    */
   CMSIS_INLINE __STATIC_INLINE void arm_circularWrite_f32(
-  int32_t * circBuffer,
-  int32_t L,
-  uint16_t * writeOffset,
-  int32_t bufferInc,
-  const int32_t * src,
-  int32_t srcInc,
-  uint32_t blockSize)
+      int32_t *circBuffer,
+      int32_t L,
+      uint16_t *writeOffset,
+      int32_t bufferInc,
+      const int32_t *src,
+      int32_t srcInc,
+      uint32_t blockSize)
   {
     uint32_t i = 0U;
     int32_t wOffset;
@@ -5823,21 +5553,19 @@ void arm_rfft_fast_f32(
     *writeOffset = (uint16_t)wOffset;
   }
 
-
-
   /**
    * @brief floating-point Circular Read function.
    */
   CMSIS_INLINE __STATIC_INLINE void arm_circularRead_f32(
-  int32_t * circBuffer,
-  int32_t L,
-  int32_t * readOffset,
-  int32_t bufferInc,
-  int32_t * dst,
-  int32_t * dst_base,
-  int32_t dst_length,
-  int32_t dstInc,
-  uint32_t blockSize)
+      int32_t *circBuffer,
+      int32_t L,
+      int32_t *readOffset,
+      int32_t bufferInc,
+      int32_t *dst,
+      int32_t *dst_base,
+      int32_t dst_length,
+      int32_t dstInc,
+      uint32_t blockSize)
   {
     uint32_t i = 0U;
     int32_t rOffset, dst_end;
@@ -5845,7 +5573,7 @@ void arm_rfft_fast_f32(
     /* Copy the value of Index pointer that points
      * to the current location from where the input samples to be read */
     rOffset = *readOffset;
-    dst_end = (int32_t) (dst_base + dst_length);
+    dst_end = (int32_t)(dst_base + dst_length);
 
     /* Loop over the blockSize */
     i = blockSize;
@@ -5858,7 +5586,7 @@ void arm_rfft_fast_f32(
       /* Update the input pointer */
       dst += dstInc;
 
-      if (dst == (int32_t *) dst_end)
+      if (dst == (int32_t *)dst_end)
       {
         dst = dst_base;
       }
@@ -5879,18 +5607,17 @@ void arm_rfft_fast_f32(
     *readOffset = rOffset;
   }
 
-
   /**
    * @brief Q15 Circular write function.
    */
   CMSIS_INLINE __STATIC_INLINE void arm_circularWrite_q15(
-  q15_t * circBuffer,
-  int32_t L,
-  uint16_t * writeOffset,
-  int32_t bufferInc,
-  const q15_t * src,
-  int32_t srcInc,
-  uint32_t blockSize)
+      q15_t *circBuffer,
+      int32_t L,
+      uint16_t *writeOffset,
+      int32_t bufferInc,
+      const q15_t *src,
+      int32_t srcInc,
+      uint32_t blockSize)
   {
     uint32_t i = 0U;
     int32_t wOffset;
@@ -5923,20 +5650,19 @@ void arm_rfft_fast_f32(
     *writeOffset = (uint16_t)wOffset;
   }
 
-
   /**
    * @brief Q15 Circular Read function.
    */
   CMSIS_INLINE __STATIC_INLINE void arm_circularRead_q15(
-  q15_t * circBuffer,
-  int32_t L,
-  int32_t * readOffset,
-  int32_t bufferInc,
-  q15_t * dst,
-  q15_t * dst_base,
-  int32_t dst_length,
-  int32_t dstInc,
-  uint32_t blockSize)
+      q15_t *circBuffer,
+      int32_t L,
+      int32_t *readOffset,
+      int32_t bufferInc,
+      q15_t *dst,
+      q15_t *dst_base,
+      int32_t dst_length,
+      int32_t dstInc,
+      uint32_t blockSize)
   {
     uint32_t i = 0;
     int32_t rOffset, dst_end;
@@ -5945,7 +5671,7 @@ void arm_rfft_fast_f32(
      * to the current location from where the input samples to be read */
     rOffset = *readOffset;
 
-    dst_end = (int32_t) (dst_base + dst_length);
+    dst_end = (int32_t)(dst_base + dst_length);
 
     /* Loop over the blockSize */
     i = blockSize;
@@ -5958,7 +5684,7 @@ void arm_rfft_fast_f32(
       /* Update the input pointer */
       dst += dstInc;
 
-      if (dst == (q15_t *) dst_end)
+      if (dst == (q15_t *)dst_end)
       {
         dst = dst_base;
       }
@@ -5979,18 +5705,17 @@ void arm_rfft_fast_f32(
     *readOffset = rOffset;
   }
 
-
   /**
    * @brief Q7 Circular write function.
    */
   CMSIS_INLINE __STATIC_INLINE void arm_circularWrite_q7(
-  q7_t * circBuffer,
-  int32_t L,
-  uint16_t * writeOffset,
-  int32_t bufferInc,
-  const q7_t * src,
-  int32_t srcInc,
-  uint32_t blockSize)
+      q7_t *circBuffer,
+      int32_t L,
+      uint16_t *writeOffset,
+      int32_t bufferInc,
+      const q7_t *src,
+      int32_t srcInc,
+      uint32_t blockSize)
   {
     uint32_t i = 0U;
     int32_t wOffset;
@@ -6023,20 +5748,19 @@ void arm_rfft_fast_f32(
     *writeOffset = (uint16_t)wOffset;
   }
 
-
   /**
    * @brief Q7 Circular Read function.
    */
   CMSIS_INLINE __STATIC_INLINE void arm_circularRead_q7(
-  q7_t * circBuffer,
-  int32_t L,
-  int32_t * readOffset,
-  int32_t bufferInc,
-  q7_t * dst,
-  q7_t * dst_base,
-  int32_t dst_length,
-  int32_t dstInc,
-  uint32_t blockSize)
+      q7_t *circBuffer,
+      int32_t L,
+      int32_t *readOffset,
+      int32_t bufferInc,
+      q7_t *dst,
+      q7_t *dst_base,
+      int32_t dst_length,
+      int32_t dstInc,
+      uint32_t blockSize)
   {
     uint32_t i = 0;
     int32_t rOffset, dst_end;
@@ -6045,7 +5769,7 @@ void arm_rfft_fast_f32(
      * to the current location from where the input samples to be read */
     rOffset = *readOffset;
 
-    dst_end = (int32_t) (dst_base + dst_length);
+    dst_end = (int32_t)(dst_base + dst_length);
 
     /* Loop over the blockSize */
     i = blockSize;
@@ -6058,7 +5782,7 @@ void arm_rfft_fast_f32(
       /* Update the input pointer */
       dst += dstInc;
 
-      if (dst == (q7_t *) dst_end)
+      if (dst == (q7_t *)dst_end)
       {
         dst = dst_base;
       }
@@ -6079,7 +5803,6 @@ void arm_rfft_fast_f32(
     *readOffset = rOffset;
   }
 
-
   /**
    * @brief  Sum of the squares of the elements of a Q31 vector.
    * @param[in]  pSrc       is input pointer
@@ -6087,10 +5810,9 @@ void arm_rfft_fast_f32(
    * @param[out] pResult    is output value.
    */
   void arm_power_q31(
-  q31_t * pSrc,
-  uint32_t blockSize,
-  q63_t * pResult);
-
+      q31_t *pSrc,
+      uint32_t blockSize,
+      q63_t *pResult);
 
   /**
    * @brief  Sum of the squares of the elements of a floating-point vector.
@@ -6099,10 +5821,9 @@ void arm_rfft_fast_f32(
    * @param[out] pResult    is output value.
    */
   void arm_power_f32(
-  float32_t * pSrc,
-  uint32_t blockSize,
-  float32_t * pResult);
-
+      float32_t *pSrc,
+      uint32_t blockSize,
+      float32_t *pResult);
 
   /**
    * @brief  Sum of the squares of the elements of a Q15 vector.
@@ -6111,10 +5832,9 @@ void arm_rfft_fast_f32(
    * @param[out] pResult    is output value.
    */
   void arm_power_q15(
-  q15_t * pSrc,
-  uint32_t blockSize,
-  q63_t * pResult);
-
+      q15_t *pSrc,
+      uint32_t blockSize,
+      q63_t *pResult);
 
   /**
    * @brief  Sum of the squares of the elements of a Q7 vector.
@@ -6123,10 +5843,9 @@ void arm_rfft_fast_f32(
    * @param[out] pResult    is output value.
    */
   void arm_power_q7(
-  q7_t * pSrc,
-  uint32_t blockSize,
-  q31_t * pResult);
-
+      q7_t *pSrc,
+      uint32_t blockSize,
+      q31_t *pResult);
 
   /**
    * @brief  Mean value of a Q7 vector.
@@ -6135,10 +5854,9 @@ void arm_rfft_fast_f32(
    * @param[out] pResult    is output value.
    */
   void arm_mean_q7(
-  q7_t * pSrc,
-  uint32_t blockSize,
-  q7_t * pResult);
-
+      q7_t *pSrc,
+      uint32_t blockSize,
+      q7_t *pResult);
 
   /**
    * @brief  Mean value of a Q15 vector.
@@ -6147,10 +5865,9 @@ void arm_rfft_fast_f32(
    * @param[out] pResult    is output value.
    */
   void arm_mean_q15(
-  q15_t * pSrc,
-  uint32_t blockSize,
-  q15_t * pResult);
-
+      q15_t *pSrc,
+      uint32_t blockSize,
+      q15_t *pResult);
 
   /**
    * @brief  Mean value of a Q31 vector.
@@ -6159,10 +5876,9 @@ void arm_rfft_fast_f32(
    * @param[out] pResult    is output value.
    */
   void arm_mean_q31(
-  q31_t * pSrc,
-  uint32_t blockSize,
-  q31_t * pResult);
-
+      q31_t *pSrc,
+      uint32_t blockSize,
+      q31_t *pResult);
 
   /**
    * @brief  Mean value of a floating-point vector.
@@ -6171,10 +5887,9 @@ void arm_rfft_fast_f32(
    * @param[out] pResult    is output value.
    */
   void arm_mean_f32(
-  float32_t * pSrc,
-  uint32_t blockSize,
-  float32_t * pResult);
-
+      float32_t *pSrc,
+      uint32_t blockSize,
+      float32_t *pResult);
 
   /**
    * @brief  Variance of the elements of a floating-point vector.
@@ -6183,10 +5898,9 @@ void arm_rfft_fast_f32(
    * @param[out] pResult    is output value.
    */
   void arm_var_f32(
-  float32_t * pSrc,
-  uint32_t blockSize,
-  float32_t * pResult);
-
+      float32_t *pSrc,
+      uint32_t blockSize,
+      float32_t *pResult);
 
   /**
    * @brief  Variance of the elements of a Q31 vector.
@@ -6195,10 +5909,9 @@ void arm_rfft_fast_f32(
    * @param[out] pResult    is output value.
    */
   void arm_var_q31(
-  q31_t * pSrc,
-  uint32_t blockSize,
-  q31_t * pResult);
-
+      q31_t *pSrc,
+      uint32_t blockSize,
+      q31_t *pResult);
 
   /**
    * @brief  Variance of the elements of a Q15 vector.
@@ -6207,10 +5920,9 @@ void arm_rfft_fast_f32(
    * @param[out] pResult    is output value.
    */
   void arm_var_q15(
-  q15_t * pSrc,
-  uint32_t blockSize,
-  q15_t * pResult);
-
+      q15_t *pSrc,
+      uint32_t blockSize,
+      q15_t *pResult);
 
   /**
    * @brief  Root Mean Square of the elements of a floating-point vector.
@@ -6219,10 +5931,9 @@ void arm_rfft_fast_f32(
    * @param[out] pResult    is output value.
    */
   void arm_rms_f32(
-  float32_t * pSrc,
-  uint32_t blockSize,
-  float32_t * pResult);
-
+      float32_t *pSrc,
+      uint32_t blockSize,
+      float32_t *pResult);
 
   /**
    * @brief  Root Mean Square of the elements of a Q31 vector.
@@ -6231,10 +5942,9 @@ void arm_rfft_fast_f32(
    * @param[out] pResult    is output value.
    */
   void arm_rms_q31(
-  q31_t * pSrc,
-  uint32_t blockSize,
-  q31_t * pResult);
-
+      q31_t *pSrc,
+      uint32_t blockSize,
+      q31_t *pResult);
 
   /**
    * @brief  Root Mean Square of the elements of a Q15 vector.
@@ -6243,10 +5953,9 @@ void arm_rfft_fast_f32(
    * @param[out] pResult    is output value.
    */
   void arm_rms_q15(
-  q15_t * pSrc,
-  uint32_t blockSize,
-  q15_t * pResult);
-
+      q15_t *pSrc,
+      uint32_t blockSize,
+      q15_t *pResult);
 
   /**
    * @brief  Standard deviation of the elements of a floating-point vector.
@@ -6255,10 +5964,9 @@ void arm_rfft_fast_f32(
    * @param[out] pResult    is output value.
    */
   void arm_std_f32(
-  float32_t * pSrc,
-  uint32_t blockSize,
-  float32_t * pResult);
-
+      float32_t *pSrc,
+      uint32_t blockSize,
+      float32_t *pResult);
 
   /**
    * @brief  Standard deviation of the elements of a Q31 vector.
@@ -6267,10 +5975,9 @@ void arm_rfft_fast_f32(
    * @param[out] pResult    is output value.
    */
   void arm_std_q31(
-  q31_t * pSrc,
-  uint32_t blockSize,
-  q31_t * pResult);
-
+      q31_t *pSrc,
+      uint32_t blockSize,
+      q31_t *pResult);
 
   /**
    * @brief  Standard deviation of the elements of a Q15 vector.
@@ -6279,10 +5986,9 @@ void arm_rfft_fast_f32(
    * @param[out] pResult    is output value.
    */
   void arm_std_q15(
-  q15_t * pSrc,
-  uint32_t blockSize,
-  q15_t * pResult);
-
+      q15_t *pSrc,
+      uint32_t blockSize,
+      q15_t *pResult);
 
   /**
    * @brief  Floating-point complex magnitude
@@ -6291,10 +5997,9 @@ void arm_rfft_fast_f32(
    * @param[in]  numSamples  number of complex samples in the input vector
    */
   void arm_cmplx_mag_f32(
-  float32_t * pSrc,
-  float32_t * pDst,
-  uint32_t numSamples);
-
+      float32_t *pSrc,
+      float32_t *pDst,
+      uint32_t numSamples);
 
   /**
    * @brief  Q31 complex magnitude
@@ -6303,10 +6008,9 @@ void arm_rfft_fast_f32(
    * @param[in]  numSamples  number of complex samples in the input vector
    */
   void arm_cmplx_mag_q31(
-  q31_t * pSrc,
-  q31_t * pDst,
-  uint32_t numSamples);
-
+      q31_t *pSrc,
+      q31_t *pDst,
+      uint32_t numSamples);
 
   /**
    * @brief  Q15 complex magnitude
@@ -6315,10 +6019,9 @@ void arm_rfft_fast_f32(
    * @param[in]  numSamples  number of complex samples in the input vector
    */
   void arm_cmplx_mag_q15(
-  q15_t * pSrc,
-  q15_t * pDst,
-  uint32_t numSamples);
-
+      q15_t *pSrc,
+      q15_t *pDst,
+      uint32_t numSamples);
 
   /**
    * @brief  Q15 complex dot product
@@ -6329,12 +6032,11 @@ void arm_rfft_fast_f32(
    * @param[out] imagResult  imaginary part of the result returned here
    */
   void arm_cmplx_dot_prod_q15(
-  q15_t * pSrcA,
-  q15_t * pSrcB,
-  uint32_t numSamples,
-  q31_t * realResult,
-  q31_t * imagResult);
-
+      q15_t *pSrcA,
+      q15_t *pSrcB,
+      uint32_t numSamples,
+      q31_t *realResult,
+      q31_t *imagResult);
 
   /**
    * @brief  Q31 complex dot product
@@ -6345,12 +6047,11 @@ void arm_rfft_fast_f32(
    * @param[out] imagResult  imaginary part of the result returned here
    */
   void arm_cmplx_dot_prod_q31(
-  q31_t * pSrcA,
-  q31_t * pSrcB,
-  uint32_t numSamples,
-  q63_t * realResult,
-  q63_t * imagResult);
-
+      q31_t *pSrcA,
+      q31_t *pSrcB,
+      uint32_t numSamples,
+      q63_t *realResult,
+      q63_t *imagResult);
 
   /**
    * @brief  Floating-point complex dot product
@@ -6361,12 +6062,11 @@ void arm_rfft_fast_f32(
    * @param[out] imagResult  imaginary part of the result returned here
    */
   void arm_cmplx_dot_prod_f32(
-  float32_t * pSrcA,
-  float32_t * pSrcB,
-  uint32_t numSamples,
-  float32_t * realResult,
-  float32_t * imagResult);
-
+      float32_t *pSrcA,
+      float32_t *pSrcB,
+      uint32_t numSamples,
+      float32_t *realResult,
+      float32_t *imagResult);
 
   /**
    * @brief  Q15 complex-by-real multiplication
@@ -6376,11 +6076,10 @@ void arm_rfft_fast_f32(
    * @param[in]  numSamples  number of samples in each vector
    */
   void arm_cmplx_mult_real_q15(
-  q15_t * pSrcCmplx,
-  q15_t * pSrcReal,
-  q15_t * pCmplxDst,
-  uint32_t numSamples);
-
+      q15_t *pSrcCmplx,
+      q15_t *pSrcReal,
+      q15_t *pCmplxDst,
+      uint32_t numSamples);
 
   /**
    * @brief  Q31 complex-by-real multiplication
@@ -6390,11 +6089,10 @@ void arm_rfft_fast_f32(
    * @param[in]  numSamples  number of samples in each vector
    */
   void arm_cmplx_mult_real_q31(
-  q31_t * pSrcCmplx,
-  q31_t * pSrcReal,
-  q31_t * pCmplxDst,
-  uint32_t numSamples);
-
+      q31_t *pSrcCmplx,
+      q31_t *pSrcReal,
+      q31_t *pCmplxDst,
+      uint32_t numSamples);
 
   /**
    * @brief  Floating-point complex-by-real multiplication
@@ -6404,11 +6102,10 @@ void arm_rfft_fast_f32(
    * @param[in]  numSamples  number of samples in each vector
    */
   void arm_cmplx_mult_real_f32(
-  float32_t * pSrcCmplx,
-  float32_t * pSrcReal,
-  float32_t * pCmplxDst,
-  uint32_t numSamples);
-
+      float32_t *pSrcCmplx,
+      float32_t *pSrcReal,
+      float32_t *pCmplxDst,
+      uint32_t numSamples);
 
   /**
    * @brief  Minimum value of a Q7 vector.
@@ -6418,11 +6115,10 @@ void arm_rfft_fast_f32(
    * @param[in]  index      is the array index of the minimum value in the input buffer.
    */
   void arm_min_q7(
-  q7_t * pSrc,
-  uint32_t blockSize,
-  q7_t * result,
-  uint32_t * index);
-
+      q7_t *pSrc,
+      uint32_t blockSize,
+      q7_t *result,
+      uint32_t *index);
 
   /**
    * @brief  Minimum value of a Q15 vector.
@@ -6432,11 +6128,10 @@ void arm_rfft_fast_f32(
    * @param[in]  pIndex     is the array index of the minimum value in the input buffer.
    */
   void arm_min_q15(
-  q15_t * pSrc,
-  uint32_t blockSize,
-  q15_t * pResult,
-  uint32_t * pIndex);
-
+      q15_t *pSrc,
+      uint32_t blockSize,
+      q15_t *pResult,
+      uint32_t *pIndex);
 
   /**
    * @brief  Minimum value of a Q31 vector.
@@ -6446,11 +6141,10 @@ void arm_rfft_fast_f32(
    * @param[out] pIndex     is the array index of the minimum value in the input buffer.
    */
   void arm_min_q31(
-  q31_t * pSrc,
-  uint32_t blockSize,
-  q31_t * pResult,
-  uint32_t * pIndex);
-
+      q31_t *pSrc,
+      uint32_t blockSize,
+      q31_t *pResult,
+      uint32_t *pIndex);
 
   /**
    * @brief  Minimum value of a floating-point vector.
@@ -6460,13 +6154,12 @@ void arm_rfft_fast_f32(
    * @param[out] pIndex     is the array index of the minimum value in the input buffer.
    */
   void arm_min_f32(
-  float32_t * pSrc,
-  uint32_t blockSize,
-  float32_t * pResult,
-  uint32_t * pIndex);
+      float32_t *pSrc,
+      uint32_t blockSize,
+      float32_t *pResult,
+      uint32_t *pIndex);
 
-
-/**
+  /**
  * @brief Maximum value of a Q7 vector.
  * @param[in]  pSrc       points to the input buffer
  * @param[in]  blockSize  length of the input vector
@@ -6474,13 +6167,12 @@ void arm_rfft_fast_f32(
  * @param[out] pIndex     index of maximum value returned here
  */
   void arm_max_q7(
-  q7_t * pSrc,
-  uint32_t blockSize,
-  q7_t * pResult,
-  uint32_t * pIndex);
+      q7_t *pSrc,
+      uint32_t blockSize,
+      q7_t *pResult,
+      uint32_t *pIndex);
 
-
-/**
+  /**
  * @brief Maximum value of a Q15 vector.
  * @param[in]  pSrc       points to the input buffer
  * @param[in]  blockSize  length of the input vector
@@ -6488,13 +6180,12 @@ void arm_rfft_fast_f32(
  * @param[out] pIndex     index of maximum value returned here
  */
   void arm_max_q15(
-  q15_t * pSrc,
-  uint32_t blockSize,
-  q15_t * pResult,
-  uint32_t * pIndex);
+      q15_t *pSrc,
+      uint32_t blockSize,
+      q15_t *pResult,
+      uint32_t *pIndex);
 
-
-/**
+  /**
  * @brief Maximum value of a Q31 vector.
  * @param[in]  pSrc       points to the input buffer
  * @param[in]  blockSize  length of the input vector
@@ -6502,13 +6193,12 @@ void arm_rfft_fast_f32(
  * @param[out] pIndex     index of maximum value returned here
  */
   void arm_max_q31(
-  q31_t * pSrc,
-  uint32_t blockSize,
-  q31_t * pResult,
-  uint32_t * pIndex);
+      q31_t *pSrc,
+      uint32_t blockSize,
+      q31_t *pResult,
+      uint32_t *pIndex);
 
-
-/**
+  /**
  * @brief Maximum value of a floating-point vector.
  * @param[in]  pSrc       points to the input buffer
  * @param[in]  blockSize  length of the input vector
@@ -6516,11 +6206,10 @@ void arm_rfft_fast_f32(
  * @param[out] pIndex     index of maximum value returned here
  */
   void arm_max_f32(
-  float32_t * pSrc,
-  uint32_t blockSize,
-  float32_t * pResult,
-  uint32_t * pIndex);
-
+      float32_t *pSrc,
+      uint32_t blockSize,
+      float32_t *pResult,
+      uint32_t *pIndex);
 
   /**
    * @brief  Q15 complex-by-complex multiplication
@@ -6530,11 +6219,10 @@ void arm_rfft_fast_f32(
    * @param[in]  numSamples  number of complex samples in each vector
    */
   void arm_cmplx_mult_cmplx_q15(
-  q15_t * pSrcA,
-  q15_t * pSrcB,
-  q15_t * pDst,
-  uint32_t numSamples);
-
+      q15_t *pSrcA,
+      q15_t *pSrcB,
+      q15_t *pDst,
+      uint32_t numSamples);
 
   /**
    * @brief  Q31 complex-by-complex multiplication
@@ -6544,11 +6232,10 @@ void arm_rfft_fast_f32(
    * @param[in]  numSamples  number of complex samples in each vector
    */
   void arm_cmplx_mult_cmplx_q31(
-  q31_t * pSrcA,
-  q31_t * pSrcB,
-  q31_t * pDst,
-  uint32_t numSamples);
-
+      q31_t *pSrcA,
+      q31_t *pSrcB,
+      q31_t *pDst,
+      uint32_t numSamples);
 
   /**
    * @brief  Floating-point complex-by-complex multiplication
@@ -6558,11 +6245,10 @@ void arm_rfft_fast_f32(
    * @param[in]  numSamples  number of complex samples in each vector
    */
   void arm_cmplx_mult_cmplx_f32(
-  float32_t * pSrcA,
-  float32_t * pSrcB,
-  float32_t * pDst,
-  uint32_t numSamples);
-
+      float32_t *pSrcA,
+      float32_t *pSrcB,
+      float32_t *pDst,
+      uint32_t numSamples);
 
   /**
    * @brief Converts the elements of the floating-point vector to Q31 vector.
@@ -6571,10 +6257,9 @@ void arm_rfft_fast_f32(
    * @param[in]  blockSize  length of the input vector
    */
   void arm_float_to_q31(
-  float32_t * pSrc,
-  q31_t * pDst,
-  uint32_t blockSize);
-
+      float32_t *pSrc,
+      q31_t *pDst,
+      uint32_t blockSize);
 
   /**
    * @brief Converts the elements of the floating-point vector to Q15 vector.
@@ -6583,10 +6268,9 @@ void arm_rfft_fast_f32(
    * @param[in]  blockSize  length of the input vector
    */
   void arm_float_to_q15(
-  float32_t * pSrc,
-  q15_t * pDst,
-  uint32_t blockSize);
-
+      float32_t *pSrc,
+      q15_t *pDst,
+      uint32_t blockSize);
 
   /**
    * @brief Converts the elements of the floating-point vector to Q7 vector.
@@ -6595,10 +6279,9 @@ void arm_rfft_fast_f32(
    * @param[in]  blockSize  length of the input vector
    */
   void arm_float_to_q7(
-  float32_t * pSrc,
-  q7_t * pDst,
-  uint32_t blockSize);
-
+      float32_t *pSrc,
+      q7_t *pDst,
+      uint32_t blockSize);
 
   /**
    * @brief  Converts the elements of the Q31 vector to Q15 vector.
@@ -6607,10 +6290,9 @@ void arm_rfft_fast_f32(
    * @param[in]  blockSize  is the number of samples to process
    */
   void arm_q31_to_q15(
-  q31_t * pSrc,
-  q15_t * pDst,
-  uint32_t blockSize);
-
+      q31_t *pSrc,
+      q15_t *pDst,
+      uint32_t blockSize);
 
   /**
    * @brief  Converts the elements of the Q31 vector to Q7 vector.
@@ -6619,10 +6301,9 @@ void arm_rfft_fast_f32(
    * @param[in]  blockSize  is the number of samples to process
    */
   void arm_q31_to_q7(
-  q31_t * pSrc,
-  q7_t * pDst,
-  uint32_t blockSize);
-
+      q31_t *pSrc,
+      q7_t *pDst,
+      uint32_t blockSize);
 
   /**
    * @brief  Converts the elements of the Q15 vector to floating-point vector.
@@ -6631,10 +6312,9 @@ void arm_rfft_fast_f32(
    * @param[in]  blockSize  is the number of samples to process
    */
   void arm_q15_to_float(
-  q15_t * pSrc,
-  float32_t * pDst,
-  uint32_t blockSize);
-
+      q15_t *pSrc,
+      float32_t *pDst,
+      uint32_t blockSize);
 
   /**
    * @brief  Converts the elements of the Q15 vector to Q31 vector.
@@ -6643,10 +6323,9 @@ void arm_rfft_fast_f32(
    * @param[in]  blockSize  is the number of samples to process
    */
   void arm_q15_to_q31(
-  q15_t * pSrc,
-  q31_t * pDst,
-  uint32_t blockSize);
-
+      q15_t *pSrc,
+      q31_t *pDst,
+      uint32_t blockSize);
 
   /**
    * @brief  Converts the elements of the Q15 vector to Q7 vector.
@@ -6655,10 +6334,9 @@ void arm_rfft_fast_f32(
    * @param[in]  blockSize  is the number of samples to process
    */
   void arm_q15_to_q7(
-  q15_t * pSrc,
-  q7_t * pDst,
-  uint32_t blockSize);
-
+      q15_t *pSrc,
+      q7_t *pDst,
+      uint32_t blockSize);
 
   /**
    * @ingroup groupInterpolation
@@ -6721,7 +6399,6 @@ void arm_rfft_fast_f32(
    * @{
    */
 
-
   /**
   *
   * @brief  Floating-point bilinear interpolation.
@@ -6731,9 +6408,9 @@ void arm_rfft_fast_f32(
   * @return out interpolated value.
   */
   CMSIS_INLINE __STATIC_INLINE float32_t arm_bilinear_interp_f32(
-  const arm_bilinear_interp_instance_f32 * S,
-  float32_t X,
-  float32_t Y)
+      const arm_bilinear_interp_instance_f32 *S,
+      float32_t X,
+      float32_t Y)
   {
     float32_t out;
     float32_t f00, f01, f10, f11;
@@ -6742,8 +6419,8 @@ void arm_rfft_fast_f32(
     float32_t xdiff, ydiff;
     float32_t b1, b2, b3, b4;
 
-    xIndex = (int32_t) X;
-    yIndex = (int32_t) Y;
+    xIndex = (int32_t)X;
+    yIndex = (int32_t)Y;
 
     /* Care taken for table outside boundary */
     /* Returns zero output when values are outside table boundary */
@@ -6755,14 +6432,12 @@ void arm_rfft_fast_f32(
     /* Calculation of index for two nearest points in X-direction */
     index = (xIndex - 1) + (yIndex - 1) * S->numCols;
 
-
     /* Read two nearest points in X-direction */
     f00 = pData[index];
     f01 = pData[index + 1];
 
     /* Calculation of index for two nearest points in Y-direction */
-    index = (xIndex - 1) + (yIndex) * S->numCols;
-
+    index = (xIndex - 1) + (yIndex)*S->numCols;
 
     /* Read two nearest points in Y-direction */
     f10 = pData[index];
@@ -6787,7 +6462,6 @@ void arm_rfft_fast_f32(
     return (out);
   }
 
-
   /**
   *
   * @brief  Q31 bilinear interpolation.
@@ -6797,17 +6471,17 @@ void arm_rfft_fast_f32(
   * @return out interpolated value.
   */
   CMSIS_INLINE __STATIC_INLINE q31_t arm_bilinear_interp_q31(
-  arm_bilinear_interp_instance_q31 * S,
-  q31_t X,
-  q31_t Y)
+      arm_bilinear_interp_instance_q31 *S,
+      q31_t X,
+      q31_t Y)
   {
-    q31_t out;                                   /* Temporary output */
-    q31_t acc = 0;                               /* output */
-    q31_t xfract, yfract;                        /* X, Y fractional parts */
-    q31_t x1, x2, y1, y2;                        /* Nearest output values */
-    int32_t rI, cI;                              /* Row and column indices */
-    q31_t *pYData = S->pData;                    /* pointer to output table values */
-    uint32_t nCols = S->numCols;                 /* num of rows */
+    q31_t out;                   /* Temporary output */
+    q31_t acc = 0;               /* output */
+    q31_t xfract, yfract;        /* X, Y fractional parts */
+    q31_t x1, x2, y1, y2;        /* Nearest output values */
+    int32_t rI, cI;              /* Row and column indices */
+    q31_t *pYData = S->pData;    /* pointer to output table values */
+    uint32_t nCols = S->numCols; /* num of rows */
 
     /* Input is in 12.20 format */
     /* 12 bits for the table index */
@@ -6831,7 +6505,7 @@ void arm_rfft_fast_f32(
     xfract = (X & 0x000FFFFF) << 11U;
 
     /* Read two nearest output values from the index */
-    x1 = pYData[(rI) + (int32_t)nCols * (cI)    ];
+    x1 = pYData[(rI) + (int32_t)nCols * (cI)];
     x2 = pYData[(rI) + (int32_t)nCols * (cI) + 1];
 
     /* 20 bits for the fractional part */
@@ -6839,29 +6513,28 @@ void arm_rfft_fast_f32(
     yfract = (Y & 0x000FFFFF) << 11U;
 
     /* Read two nearest output values from the index */
-    y1 = pYData[(rI) + (int32_t)nCols * (cI + 1)    ];
+    y1 = pYData[(rI) + (int32_t)nCols * (cI + 1)];
     y2 = pYData[(rI) + (int32_t)nCols * (cI + 1) + 1];
 
     /* Calculation of x1 * (1-xfract ) * (1-yfract) and acc is in 3.29(q29) format */
-    out = ((q31_t) (((q63_t) x1  * (0x7FFFFFFF - xfract)) >> 32));
-    acc = ((q31_t) (((q63_t) out * (0x7FFFFFFF - yfract)) >> 32));
+    out = ((q31_t)(((q63_t)x1 * (0x7FFFFFFF - xfract)) >> 32));
+    acc = ((q31_t)(((q63_t)out * (0x7FFFFFFF - yfract)) >> 32));
 
     /* x2 * (xfract) * (1-yfract)  in 3.29(q29) and adding to acc */
-    out = ((q31_t) ((q63_t) x2 * (0x7FFFFFFF - yfract) >> 32));
-    acc += ((q31_t) ((q63_t) out * (xfract) >> 32));
+    out = ((q31_t)((q63_t)x2 * (0x7FFFFFFF - yfract) >> 32));
+    acc += ((q31_t)((q63_t)out * (xfract) >> 32));
 
     /* y1 * (1 - xfract) * (yfract)  in 3.29(q29) and adding to acc */
-    out = ((q31_t) ((q63_t) y1 * (0x7FFFFFFF - xfract) >> 32));
-    acc += ((q31_t) ((q63_t) out * (yfract) >> 32));
+    out = ((q31_t)((q63_t)y1 * (0x7FFFFFFF - xfract) >> 32));
+    acc += ((q31_t)((q63_t)out * (yfract) >> 32));
 
     /* y2 * (xfract) * (yfract)  in 3.29(q29) and adding to acc */
-    out = ((q31_t) ((q63_t) y2 * (xfract) >> 32));
-    acc += ((q31_t) ((q63_t) out * (yfract) >> 32));
+    out = ((q31_t)((q63_t)y2 * (xfract) >> 32));
+    acc += ((q31_t)((q63_t)out * (yfract) >> 32));
 
     /* Convert acc to 1.31(q31) format */
     return ((q31_t)(acc << 2));
   }
-
 
   /**
   * @brief  Q15 bilinear interpolation.
@@ -6871,17 +6544,17 @@ void arm_rfft_fast_f32(
   * @return out interpolated value.
   */
   CMSIS_INLINE __STATIC_INLINE q15_t arm_bilinear_interp_q15(
-  arm_bilinear_interp_instance_q15 * S,
-  q31_t X,
-  q31_t Y)
+      arm_bilinear_interp_instance_q15 *S,
+      q31_t X,
+      q31_t Y)
   {
-    q63_t acc = 0;                               /* output */
-    q31_t out;                                   /* Temporary output */
-    q15_t x1, x2, y1, y2;                        /* Nearest output values */
-    q31_t xfract, yfract;                        /* X, Y fractional parts */
-    int32_t rI, cI;                              /* Row and column indices */
-    q15_t *pYData = S->pData;                    /* pointer to output table values */
-    uint32_t nCols = S->numCols;                 /* num of rows */
+    q63_t acc = 0;               /* output */
+    q31_t out;                   /* Temporary output */
+    q15_t x1, x2, y1, y2;        /* Nearest output values */
+    q31_t xfract, yfract;        /* X, Y fractional parts */
+    int32_t rI, cI;              /* Row and column indices */
+    q15_t *pYData = S->pData;    /* pointer to output table values */
+    uint32_t nCols = S->numCols; /* num of rows */
 
     /* Input is in 12.20 format */
     /* 12 bits for the table index */
@@ -6905,7 +6578,7 @@ void arm_rfft_fast_f32(
     xfract = (X & 0x000FFFFF);
 
     /* Read two nearest output values from the index */
-    x1 = pYData[((uint32_t)rI) + nCols * ((uint32_t)cI)    ];
+    x1 = pYData[((uint32_t)rI) + nCols * ((uint32_t)cI)];
     x2 = pYData[((uint32_t)rI) + nCols * ((uint32_t)cI) + 1];
 
     /* 20 bits for the fractional part */
@@ -6913,33 +6586,32 @@ void arm_rfft_fast_f32(
     yfract = (Y & 0x000FFFFF);
 
     /* Read two nearest output values from the index */
-    y1 = pYData[((uint32_t)rI) + nCols * ((uint32_t)cI + 1)    ];
+    y1 = pYData[((uint32_t)rI) + nCols * ((uint32_t)cI + 1)];
     y2 = pYData[((uint32_t)rI) + nCols * ((uint32_t)cI + 1) + 1];
 
     /* Calculation of x1 * (1-xfract ) * (1-yfract) and acc is in 13.51 format */
 
     /* x1 is in 1.15(q15), xfract in 12.20 format and out is in 13.35 format */
     /* convert 13.35 to 13.31 by right shifting  and out is in 1.31 */
-    out = (q31_t) (((q63_t) x1 * (0xFFFFF - xfract)) >> 4U);
-    acc = ((q63_t) out * (0xFFFFF - yfract));
+    out = (q31_t)(((q63_t)x1 * (0xFFFFF - xfract)) >> 4U);
+    acc = ((q63_t)out * (0xFFFFF - yfract));
 
     /* x2 * (xfract) * (1-yfract)  in 1.51 and adding to acc */
-    out = (q31_t) (((q63_t) x2 * (0xFFFFF - yfract)) >> 4U);
-    acc += ((q63_t) out * (xfract));
+    out = (q31_t)(((q63_t)x2 * (0xFFFFF - yfract)) >> 4U);
+    acc += ((q63_t)out * (xfract));
 
     /* y1 * (1 - xfract) * (yfract)  in 1.51 and adding to acc */
-    out = (q31_t) (((q63_t) y1 * (0xFFFFF - xfract)) >> 4U);
-    acc += ((q63_t) out * (yfract));
+    out = (q31_t)(((q63_t)y1 * (0xFFFFF - xfract)) >> 4U);
+    acc += ((q63_t)out * (yfract));
 
     /* y2 * (xfract) * (yfract)  in 1.51 and adding to acc */
-    out = (q31_t) (((q63_t) y2 * (xfract)) >> 4U);
-    acc += ((q63_t) out * (yfract));
+    out = (q31_t)(((q63_t)y2 * (xfract)) >> 4U);
+    acc += ((q63_t)out * (yfract));
 
     /* acc is in 13.51 format and down shift acc by 36 times */
     /* Convert out to 1.15 format */
     return ((q15_t)(acc >> 36));
   }
-
 
   /**
   * @brief  Q7 bilinear interpolation.
@@ -6949,17 +6621,17 @@ void arm_rfft_fast_f32(
   * @return out interpolated value.
   */
   CMSIS_INLINE __STATIC_INLINE q7_t arm_bilinear_interp_q7(
-  arm_bilinear_interp_instance_q7 * S,
-  q31_t X,
-  q31_t Y)
+      arm_bilinear_interp_instance_q7 *S,
+      q31_t X,
+      q31_t Y)
   {
-    q63_t acc = 0;                               /* output */
-    q31_t out;                                   /* Temporary output */
-    q31_t xfract, yfract;                        /* X, Y fractional parts */
-    q7_t x1, x2, y1, y2;                         /* Nearest output values */
-    int32_t rI, cI;                              /* Row and column indices */
-    q7_t *pYData = S->pData;                     /* pointer to output table values */
-    uint32_t nCols = S->numCols;                 /* num of rows */
+    q63_t acc = 0;               /* output */
+    q31_t out;                   /* Temporary output */
+    q31_t xfract, yfract;        /* X, Y fractional parts */
+    q7_t x1, x2, y1, y2;         /* Nearest output values */
+    int32_t rI, cI;              /* Row and column indices */
+    q7_t *pYData = S->pData;     /* pointer to output table values */
+    uint32_t nCols = S->numCols; /* num of rows */
 
     /* Input is in 12.20 format */
     /* 12 bits for the table index */
@@ -6983,7 +6655,7 @@ void arm_rfft_fast_f32(
     xfract = (X & (q31_t)0x000FFFFF);
 
     /* Read two nearest output values from the index */
-    x1 = pYData[((uint32_t)rI) + nCols * ((uint32_t)cI)    ];
+    x1 = pYData[((uint32_t)rI) + nCols * ((uint32_t)cI)];
     x2 = pYData[((uint32_t)rI) + nCols * ((uint32_t)cI) + 1];
 
     /* 20 bits for the fractional part */
@@ -6991,24 +6663,24 @@ void arm_rfft_fast_f32(
     yfract = (Y & (q31_t)0x000FFFFF);
 
     /* Read two nearest output values from the index */
-    y1 = pYData[((uint32_t)rI) + nCols * ((uint32_t)cI + 1)    ];
+    y1 = pYData[((uint32_t)rI) + nCols * ((uint32_t)cI + 1)];
     y2 = pYData[((uint32_t)rI) + nCols * ((uint32_t)cI + 1) + 1];
 
     /* Calculation of x1 * (1-xfract ) * (1-yfract) and acc is in 16.47 format */
     out = ((x1 * (0xFFFFF - xfract)));
-    acc = (((q63_t) out * (0xFFFFF - yfract)));
+    acc = (((q63_t)out * (0xFFFFF - yfract)));
 
     /* x2 * (xfract) * (1-yfract)  in 2.22 and adding to acc */
     out = ((x2 * (0xFFFFF - yfract)));
-    acc += (((q63_t) out * (xfract)));
+    acc += (((q63_t)out * (xfract)));
 
     /* y1 * (1 - xfract) * (yfract)  in 2.22 and adding to acc */
     out = ((y1 * (0xFFFFF - xfract)));
-    acc += (((q63_t) out * (yfract)));
+    acc += (((q63_t)out * (yfract)));
 
     /* y2 * (xfract) * (yfract)  in 2.22 and adding to acc */
     out = ((y2 * (yfract)));
-    acc += (((q63_t) out * (xfract)));
+    acc += (((q63_t)out * (xfract)));
 
     /* acc in 16.47 format and down shift by 40 to convert to 1.7 format */
     return ((q7_t)(acc >> 40));
@@ -7018,135 +6690,132 @@ void arm_rfft_fast_f32(
    * @} end of BilinearInterpolate group
    */
 
-
 /* SMMLAR */
 #define multAcc_32x32_keep32_R(a, x, y) \
-    a = (q31_t) (((((q63_t) a) << 32) + ((q63_t) x * y) + 0x80000000LL ) >> 32)
+  a = (q31_t)(((((q63_t)a) << 32) + ((q63_t)x * y) + 0x80000000LL) >> 32)
 
 /* SMMLSR */
 #define multSub_32x32_keep32_R(a, x, y) \
-    a = (q31_t) (((((q63_t) a) << 32) - ((q63_t) x * y) + 0x80000000LL ) >> 32)
+  a = (q31_t)(((((q63_t)a) << 32) - ((q63_t)x * y) + 0x80000000LL) >> 32)
 
 /* SMMULR */
 #define mult_32x32_keep32_R(a, x, y) \
-    a = (q31_t) (((q63_t) x * y + 0x80000000LL ) >> 32)
+  a = (q31_t)(((q63_t)x * y + 0x80000000LL) >> 32)
 
 /* SMMLA */
 #define multAcc_32x32_keep32(a, x, y) \
-    a += (q31_t) (((q63_t) x * y) >> 32)
+  a += (q31_t)(((q63_t)x * y) >> 32)
 
 /* SMMLS */
 #define multSub_32x32_keep32(a, x, y) \
-    a -= (q31_t) (((q63_t) x * y) >> 32)
+  a -= (q31_t)(((q63_t)x * y) >> 32)
 
 /* SMMUL */
 #define mult_32x32_keep32(a, x, y) \
-    a = (q31_t) (((q63_t) x * y ) >> 32)
+  a = (q31_t)(((q63_t)x * y) >> 32)
 
+#if defined(__CC_ARM)
+/* Enter low optimization region - place directly above function definition */
+#if defined(ARM_MATH_CM4) || defined(ARM_MATH_CM7)
+#define LOW_OPTIMIZATION_ENTER \
+  _Pragma("push")              \
+      _Pragma("O1")
+#else
+#define LOW_OPTIMIZATION_ENTER
+#endif
 
-#if   defined ( __CC_ARM )
-  /* Enter low optimization region - place directly above function definition */
-  #if defined( ARM_MATH_CM4 ) || defined( ARM_MATH_CM7)
-    #define LOW_OPTIMIZATION_ENTER \
-       _Pragma ("push")         \
-       _Pragma ("O1")
-  #else
-    #define LOW_OPTIMIZATION_ENTER
-  #endif
+/* Exit low optimization region - place directly after end of function definition */
+#if defined(ARM_MATH_CM4) || defined(ARM_MATH_CM7)
+#define LOW_OPTIMIZATION_EXIT \
+  _Pragma("pop")
+#else
+#define LOW_OPTIMIZATION_EXIT
+#endif
 
-  /* Exit low optimization region - place directly after end of function definition */
-  #if defined ( ARM_MATH_CM4 ) || defined ( ARM_MATH_CM7 )
-    #define LOW_OPTIMIZATION_EXIT \
-       _Pragma ("pop")
-  #else
-    #define LOW_OPTIMIZATION_EXIT
-  #endif
+/* Enter low optimization region - place directly above function definition */
+#define IAR_ONLY_LOW_OPTIMIZATION_ENTER
 
-  /* Enter low optimization region - place directly above function definition */
-  #define IAR_ONLY_LOW_OPTIMIZATION_ENTER
+/* Exit low optimization region - place directly after end of function definition */
+#define IAR_ONLY_LOW_OPTIMIZATION_EXIT
 
-  /* Exit low optimization region - place directly after end of function definition */
-  #define IAR_ONLY_LOW_OPTIMIZATION_EXIT
+#elif defined(__ARMCC_VERSION) && (__ARMCC_VERSION >= 6010050)
+#define LOW_OPTIMIZATION_ENTER
+#define LOW_OPTIMIZATION_EXIT
+#define IAR_ONLY_LOW_OPTIMIZATION_ENTER
+#define IAR_ONLY_LOW_OPTIMIZATION_EXIT
 
-#elif defined (__ARMCC_VERSION ) && ( __ARMCC_VERSION >= 6010050 )
-  #define LOW_OPTIMIZATION_ENTER
-  #define LOW_OPTIMIZATION_EXIT
-  #define IAR_ONLY_LOW_OPTIMIZATION_ENTER
-  #define IAR_ONLY_LOW_OPTIMIZATION_EXIT
+#elif defined(__GNUC__)
+#define LOW_OPTIMIZATION_ENTER \
+  __attribute__((optimize("-O1")))
+#define LOW_OPTIMIZATION_EXIT
+#define IAR_ONLY_LOW_OPTIMIZATION_ENTER
+#define IAR_ONLY_LOW_OPTIMIZATION_EXIT
 
-#elif defined ( __GNUC__ )
-  #define LOW_OPTIMIZATION_ENTER \
-       __attribute__(( optimize("-O1") ))
-  #define LOW_OPTIMIZATION_EXIT
-  #define IAR_ONLY_LOW_OPTIMIZATION_ENTER
-  #define IAR_ONLY_LOW_OPTIMIZATION_EXIT
+#elif defined(__ICCARM__)
+/* Enter low optimization region - place directly above function definition */
+#if defined(ARM_MATH_CM4) || defined(ARM_MATH_CM7)
+#define LOW_OPTIMIZATION_ENTER \
+  _Pragma("optimize=low")
+#else
+#define LOW_OPTIMIZATION_ENTER
+#endif
 
-#elif defined ( __ICCARM__ )
-  /* Enter low optimization region - place directly above function definition */
-  #if defined ( ARM_MATH_CM4 ) || defined ( ARM_MATH_CM7 )
-    #define LOW_OPTIMIZATION_ENTER \
-       _Pragma ("optimize=low")
-  #else
-    #define LOW_OPTIMIZATION_ENTER
-  #endif
+/* Exit low optimization region - place directly after end of function definition */
+#define LOW_OPTIMIZATION_EXIT
 
-  /* Exit low optimization region - place directly after end of function definition */
-  #define LOW_OPTIMIZATION_EXIT
+/* Enter low optimization region - place directly above function definition */
+#if defined(ARM_MATH_CM4) || defined(ARM_MATH_CM7)
+#define IAR_ONLY_LOW_OPTIMIZATION_ENTER \
+  _Pragma("optimize=low")
+#else
+#define IAR_ONLY_LOW_OPTIMIZATION_ENTER
+#endif
 
-  /* Enter low optimization region - place directly above function definition */
-  #if defined ( ARM_MATH_CM4 ) || defined ( ARM_MATH_CM7 )
-    #define IAR_ONLY_LOW_OPTIMIZATION_ENTER \
-       _Pragma ("optimize=low")
-  #else
-    #define IAR_ONLY_LOW_OPTIMIZATION_ENTER
-  #endif
+/* Exit low optimization region - place directly after end of function definition */
+#define IAR_ONLY_LOW_OPTIMIZATION_EXIT
 
-  /* Exit low optimization region - place directly after end of function definition */
-  #define IAR_ONLY_LOW_OPTIMIZATION_EXIT
+#elif defined(__TI_ARM__)
+#define LOW_OPTIMIZATION_ENTER
+#define LOW_OPTIMIZATION_EXIT
+#define IAR_ONLY_LOW_OPTIMIZATION_ENTER
+#define IAR_ONLY_LOW_OPTIMIZATION_EXIT
 
-#elif defined ( __TI_ARM__ )
-  #define LOW_OPTIMIZATION_ENTER
-  #define LOW_OPTIMIZATION_EXIT
-  #define IAR_ONLY_LOW_OPTIMIZATION_ENTER
-  #define IAR_ONLY_LOW_OPTIMIZATION_EXIT
+#elif defined(__CSMC__)
+#define LOW_OPTIMIZATION_ENTER
+#define LOW_OPTIMIZATION_EXIT
+#define IAR_ONLY_LOW_OPTIMIZATION_ENTER
+#define IAR_ONLY_LOW_OPTIMIZATION_EXIT
 
-#elif defined ( __CSMC__ )
-  #define LOW_OPTIMIZATION_ENTER
-  #define LOW_OPTIMIZATION_EXIT
-  #define IAR_ONLY_LOW_OPTIMIZATION_ENTER
-  #define IAR_ONLY_LOW_OPTIMIZATION_EXIT
-
-#elif defined ( __TASKING__ )
-  #define LOW_OPTIMIZATION_ENTER
-  #define LOW_OPTIMIZATION_EXIT
-  #define IAR_ONLY_LOW_OPTIMIZATION_ENTER
-  #define IAR_ONLY_LOW_OPTIMIZATION_EXIT
+#elif defined(__TASKING__)
+#define LOW_OPTIMIZATION_ENTER
+#define LOW_OPTIMIZATION_EXIT
+#define IAR_ONLY_LOW_OPTIMIZATION_ENTER
+#define IAR_ONLY_LOW_OPTIMIZATION_EXIT
 
 #endif
 
-
-#ifdef   __cplusplus
+#ifdef __cplusplus
 }
 #endif
 
 /* Compiler specific diagnostic adjustment */
-#if   defined ( __CC_ARM )
+#if defined(__CC_ARM)
 
-#elif defined ( __ARMCC_VERSION ) && ( __ARMCC_VERSION >= 6010050 )
+#elif defined(__ARMCC_VERSION) && (__ARMCC_VERSION >= 6010050)
 
-#elif defined ( __GNUC__ )
+#elif defined(__GNUC__)
 #pragma GCC diagnostic pop
 
-#elif defined ( __ICCARM__ )
+#elif defined(__ICCARM__)
 
-#elif defined ( __TI_ARM__ )
+#elif defined(__TI_ARM__)
 
-#elif defined ( __CSMC__ )
+#elif defined(__CSMC__)
 
-#elif defined ( __TASKING__ )
+#elif defined(__TASKING__)
 
 #else
-  #error Unknown compiler
+#error Unknown compiler
 #endif
 
 #endif /* _ARM_MATH_H */

--- a/cores/arduino/am_sdk_ap3/CMSIS/ARM/Include/arm_math.h
+++ b/cores/arduino/am_sdk_ap3/CMSIS/ARM/Include/arm_math.h
@@ -1640,12 +1640,12 @@ extern "C"
    */
   typedef struct
   {
-    q15_t A0; /**< The derived gain, A0 = Kp + Ki + Kd . */
+    q15_t ap3_A0; /**< The derived gain, A0 = Kp + Ki + Kd . */
 #if !defined(ARM_MATH_DSP)
-    q15_t A1;
-    q15_t A2;
+    q15_t ap3_A1;
+    q15_t ap3_A2;
 #else
-  q31_t A1; /**< The derived gain A1 = -Kp - 2Kd | Kd.*/
+  q31_t ap3_A1; /**< The derived gain A1 = -Kp - 2Kd | Kd.*/
 #endif
     q15_t state[3]; /**< The state array of length 3. */
     q15_t Kp;       /**< The proportional gain. */
@@ -1658,9 +1658,9 @@ extern "C"
    */
   typedef struct
   {
-    q31_t A0;       /**< The derived gain, A0 = Kp + Ki + Kd . */
-    q31_t A1;       /**< The derived gain, A1 = -Kp - 2Kd. */
-    q31_t A2;       /**< The derived gain, A2 = Kd . */
+    q31_t ap3_A0;   /**< The derived gain, A0 = Kp + Ki + Kd . */
+    q31_t ap3_A1;   /**< The derived gain, A1 = -Kp - 2Kd. */
+    q31_t ap3_A2;   /**< The derived gain, A2 = Kd . */
     q31_t state[3]; /**< The state array of length 3. */
     q31_t Kp;       /**< The proportional gain. */
     q31_t Ki;       /**< The integral gain. */
@@ -1672,9 +1672,9 @@ extern "C"
    */
   typedef struct
   {
-    float32_t A0;       /**< The derived gain, A0 = Kp + Ki + Kd . */
-    float32_t A1;       /**< The derived gain, A1 = -Kp - 2Kd. */
-    float32_t A2;       /**< The derived gain, A2 = Kd . */
+    float32_t ap3_A0;   /**< The derived gain, A0 = Kp + Ki + Kd . */
+    float32_t ap3_A1;   /**< The derived gain, A1 = -Kp - 2Kd. */
+    float32_t ap3_A2;   /**< The derived gain, A2 = Kd . */
     float32_t state[3]; /**< The state array of length 3. */
     float32_t Kp;       /**< The proportional gain. */
     float32_t Ki;       /**< The integral gain. */
@@ -4541,8 +4541,8 @@ extern "C"
     float32_t out;
 
     /* y[n] = y[n-1] + A0 * x[n] + A1 * x[n-1] + A2 * x[n-2]  */
-    out = (S->A0 * in) +
-          (S->A1 * S->state[0]) + (S->A2 * S->state[1]) + (S->state[2]);
+    out = (S->ap3_A0 * in) +
+          (S->ap3_A1 * S->state[0]) + (S->ap3_A2 * S->state[1]) + (S->state[2]);
 
     /* Update state */
     S->state[1] = S->state[0];
@@ -4575,13 +4575,13 @@ extern "C"
     q31_t out;
 
     /* acc = A0 * x[n]  */
-    acc = (q63_t)S->A0 * in;
+    acc = (q63_t)S->ap3_A0 * in;
 
     /* acc += A1 * x[n-1] */
-    acc += (q63_t)S->A1 * S->state[0];
+    acc += (q63_t)S->ap3_A1 * S->state[0];
 
     /* acc += A2 * x[n-2]  */
-    acc += (q63_t)S->A2 * S->state[1];
+    acc += (q63_t)S->ap3_A2 * S->state[1];
 
     /* convert output to 1.31 format to add y[n-1] */
     out = (q31_t)(acc >> 31U);
@@ -4626,18 +4626,18 @@ extern "C"
     /* Implementation of PID controller */
 
     /* acc = A0 * x[n]  */
-    acc = (q31_t)__SMUAD((uint32_t)S->A0, (uint32_t)in);
+    acc = (q31_t)__SMUAD((uint32_t)S->ap3_A0, (uint32_t)in);
 
     /* acc += A1 * x[n-1] + A2 * x[n-2]  */
     vstate = __SIMD32_CONST(S->state);
-    acc = (q63_t)__SMLALD((uint32_t)S->A1, (uint32_t)*vstate, (uint64_t)acc);
+    acc = (q63_t)__SMLALD((uint32_t)S->ap3_A1, (uint32_t)*vstate, (uint64_t)acc);
 #else
   /* acc = A0 * x[n]  */
-  acc = ((q31_t)S->A0) * in;
+  acc = ((q31_t)S->ap3_A0) * in;
 
   /* acc += A1 * x[n-1] + A2 * x[n-2]  */
-  acc += (q31_t)S->A1 * S->state[0];
-  acc += (q31_t)S->A2 * S->state[1];
+  acc += (q31_t)S->ap3_A1 * S->state[0];
+  acc += (q31_t)S->ap3_A2 * S->state[1];
 #endif
 
     /* acc += y[n-1] */


### PR DESCRIPTION
This is a repeat PR. Rename A0, A1, A2 to avoid compiler conflicts with Arduino pin names.

Is there a way to do this so we don't have to fix it every SDK release?