### PR TITLE
Merge pull request #116 from sparkfun/fix-math-alternate

### DIFF
--- a/variants/artemis_thing_plus/config/variant.cpp
+++ b/variants/artemis_thing_plus/config/variant.cpp
@@ -60,3 +60,13 @@ const ap3_gpio_pad_t ap3_variant_pinmap[AP3_VARIANT_NUM_PINS] = {
 //Serial(instance, RX, TX)
 Uart Serial(0, 26, 25); // Declares a Uart object called Serial using instance 0 of Apollo3 UART peripherals with RX on variant pin 26 and TX on pin 25 (note, you specify *pins* not Apollo3 pads. This uses the variant's pin map to determine the Apollo3 pad)
 Uart Serial1(1, 0, 1);  // Declares a Uart object called Serial1 using instance 1 of Apollo3 UART peripherals with RX on pin 0 and TX on pin 1 (note, you specify *pins* not Apollo3 pads. This uses the variant's pin map to determine the Apollo3 pad)
+
+// Analog pin numbers
+const ap3_gpio_pin_t ap3_analog_A0 = 19;
+const ap3_gpio_pin_t ap3_analog_A1 = 20;
+const ap3_gpio_pin_t ap3_analog_A2 = 21;
+const ap3_gpio_pin_t ap3_analog_A3 = 22;
+const ap3_gpio_pin_t ap3_analog_A4 = 23;
+const ap3_gpio_pin_t ap3_analog_A5 = 24;
+const ap3_gpio_pin_t ap3_analog_A6 = 3;
+const ap3_gpio_pin_t ap3_analog_A7 = 9;

--- a/variants/artemis_thing_plus/config/variant.h
+++ b/variants/artemis_thing_plus/config/variant.h
@@ -48,14 +48,25 @@ extern Uart Serial1;
 #define AP3_SPI_DUP ap3_spi_full_duplex // Specify that SPI is full-duplex (as opposed to ap3_spi_tx_only or ap3_spi_rx_only)
 
 // Mapping of analog pins to digital pins of variant
-#define A0 19
-#define A1 20
-#define A2 21
-#define A3 22
-#define A4 23
-#define A5 24
-#define A6 3
-#define A7 9
+// (this method - aliasing the name of a constant variable - is compatible with the usage of 'AX' names in 'arm_math.h')
+#define A0 ap3_analog_A0
+#define A1 ap3_analog_A1
+#define A2 ap3_analog_A2
+#define A3 ap3_analog_A3
+#define A4 ap3_analog_A4
+#define A5 ap3_analog_A5
+#define A6 ap3_analog_A6
+#define A7 ap3_analog_A7
+
+// Promise the existence of analog pin names
+extern const ap3_gpio_pin_t ap3_analog_A0;
+extern const ap3_gpio_pin_t ap3_analog_A1;
+extern const ap3_gpio_pin_t ap3_analog_A2;
+extern const ap3_gpio_pin_t ap3_analog_A3;
+extern const ap3_gpio_pin_t ap3_analog_A4;
+extern const ap3_gpio_pin_t ap3_analog_A5;
+extern const ap3_gpio_pin_t ap3_analog_A6;
+extern const ap3_gpio_pin_t ap3_analog_A7;
 
 #define LED_BUILTIN 18
 

--- a/variants/redboard_artemis/config/variant.cpp
+++ b/variants/redboard_artemis/config/variant.cpp
@@ -63,3 +63,16 @@ const ap3_gpio_pad_t ap3_variant_pinmap[AP3_VARIANT_NUM_PINS] = {
 //Serial(instance, RX, TX)
 Uart Serial(0, 23, 22); // Declares a Uart object called Serial using instance 0 of Apollo3 UART peripherals with RX on variant pin 23 and TX on pin 24 (note, you specify *pins* not Apollo3 pads. This uses the variant's pin map to determine the Apollo3 pad)
 Uart Serial1(1, 0, 1);  // Declares a Uart object called Serial1 using instance 1 of Apollo3 UART peripherals with RX on pin 0 and TX on pin 1 (note, you specify *pins* not Apollo3 pads. This uses the variant's pin map to determine the Apollo3 pad)
+
+// Analog pin numbers
+const ap3_gpio_pin_t ap3_analog_A0 = 16;
+const ap3_gpio_pin_t ap3_analog_A1 = 17;
+const ap3_gpio_pin_t ap3_analog_A2 = 18;
+const ap3_gpio_pin_t ap3_analog_A3 = 19;
+const ap3_gpio_pin_t ap3_analog_A4 = 20;
+const ap3_gpio_pin_t ap3_analog_A5 = 21;
+const ap3_gpio_pin_t ap3_analog_A6 = 2;
+//No A7 for better alignment
+const ap3_gpio_pin_t ap3_analog_A8 = 8;
+const ap3_gpio_pin_t ap3_analog_A9 = 9;
+const ap3_gpio_pin_t ap3_analog_A10 = 10;

--- a/variants/redboard_artemis/config/variant.h
+++ b/variants/redboard_artemis/config/variant.h
@@ -60,17 +60,31 @@ extern Uart Serial1;
 #define AP3_SPI3_DUP ap3_spi_full_duplex
 
 // Mapping of analog pins to digital pins of variant
-#define A0 16
-#define A1 17
-#define A2 18
-#define A3 19
-#define A4 20
-#define A5 21
+// (this method - aliasing the name of a constant variable - is compatible with the usage of 'AX' names in 'arm_math.h')
+#define A0 ap3_analog_A0
+#define A1 ap3_analog_A1
+#define A2 ap3_analog_A2
+#define A3 ap3_analog_A3
+#define A4 ap3_analog_A4
+#define A5 ap3_analog_A5
 //No A7 for better alignment
-#define A6 2
-#define A8 8
-#define A9 9
-#define A10 10
+#define A6 ap3_analog_A6
+#define A8 ap3_analog_A8
+#define A9 ap3_analog_A9
+#define A10 ap3_analog_A10
+
+// Promise the existence of analog pin names
+extern const ap3_gpio_pin_t ap3_analog_A0;
+extern const ap3_gpio_pin_t ap3_analog_A1;
+extern const ap3_gpio_pin_t ap3_analog_A2;
+extern const ap3_gpio_pin_t ap3_analog_A3;
+extern const ap3_gpio_pin_t ap3_analog_A4;
+extern const ap3_gpio_pin_t ap3_analog_A5;
+extern const ap3_gpio_pin_t ap3_analog_A6;
+//No A7 for better alignment
+extern const ap3_gpio_pin_t ap3_analog_A8;
+extern const ap3_gpio_pin_t ap3_analog_A9;
+extern const ap3_gpio_pin_t ap3_analog_A10;
 
 #define LED_BUILTIN 13
 

--- a/variants/redboard_artemis_atp/config/variant.cpp
+++ b/variants/redboard_artemis_atp/config/variant.cpp
@@ -80,3 +80,14 @@ const ap3_gpio_pad_t ap3_variant_pinmap[AP3_VARIANT_NUM_PINS] = {
 //Serial(instance, RX, TX)
 Uart Serial(0, 49, 48);  // Declares a Uart object called Serial using instance 0 of Apollo3 UART peripherals with RX on variant pin 49 and TX on pin 48 (note, you specify *pins* not Apollo3 pads. This uses the variant's pin map to determine the Apollo3 pad)
 Uart Serial1(1, 25, 24); // Declares a Uart object called Serial1 using instance 1 of Apollo3 UART peripherals with RX on pin 25 and TX on pin 24 (note, you specify *pins* not Apollo3 pads. This uses the variant's pin map to determine the Apollo3 pad)
+
+// Mapping of analog pins to digital pins of variant
+extern const ap3_gpio_pin_t ap3_analog_A29 = 29;
+extern const ap3_gpio_pin_t ap3_analog_A11 = 11;
+extern const ap3_gpio_pin_t ap3_analog_A34 = 34;
+extern const ap3_gpio_pin_t ap3_analog_A16 = 16;
+extern const ap3_gpio_pin_t ap3_analog_A31 = 31;
+extern const ap3_gpio_pin_t ap3_analog_A13 = 13;
+extern const ap3_gpio_pin_t ap3_analog_A12 = 12;
+extern const ap3_gpio_pin_t ap3_analog_A33 = 33;
+extern const ap3_gpio_pin_t ap3_analog_A35 = 35;

--- a/variants/redboard_artemis_atp/config/variant.h
+++ b/variants/redboard_artemis_atp/config/variant.h
@@ -47,16 +47,27 @@ extern Uart Serial1;
 #define AP3_SPI_DUP ap3_spi_full_duplex // Specify that SPI is full-duplex (as opposed to ap3_spi_tx_only or ap3_spi_rx_only)
 
 // Mapping of analog pins to digital pins of variant
-#define A29 29
-#define A11 11
-#define A34 34
-#define A33 33
-#define A16 16
-#define A31 31
-#define A13 13
-#define A12 12
-#define A33 33
-#define A35 35
+// (this method - aliasing the name of a constant variable - is compatible with the usage of 'AX' names in 'arm_math.h')
+#define A29 ap3_analog_A29
+#define A11 ap3_analog_A11
+#define A34 ap3_analog_A34
+#define A16 ap3_analog_A16
+#define A31 ap3_analog_A31
+#define A13 ap3_analog_A13
+#define A12 ap3_analog_A12
+#define A33 ap3_analog_A33
+#define A35 ap3_analog_A35
+
+// Promise the existence of analog pin names
+extern const ap3_gpio_pin_t ap3_analog_A29;
+extern const ap3_gpio_pin_t ap3_analog_A11;
+extern const ap3_gpio_pin_t ap3_analog_A34;
+extern const ap3_gpio_pin_t ap3_analog_A16;
+extern const ap3_gpio_pin_t ap3_analog_A31;
+extern const ap3_gpio_pin_t ap3_analog_A13;
+extern const ap3_gpio_pin_t ap3_analog_A12;
+extern const ap3_gpio_pin_t ap3_analog_A33;
+extern const ap3_gpio_pin_t ap3_analog_A35;
 
 #define LED_BUILTIN 5
 

--- a/variants/redboard_artemis_nano/config/variant.cpp
+++ b/variants/redboard_artemis_nano/config/variant.cpp
@@ -55,3 +55,13 @@ const ap3_gpio_pad_t ap3_variant_pinmap[AP3_VARIANT_NUM_PINS] = {
 //Serial(instance, RX, TX)
 Uart Serial(0, 21, 20); // Declares a Uart object called Serial using instance 0 of Apollo3 UART peripherals with RX on variant pin 49 and TX on pin 48 (note, you specify *pins* not Apollo3 pads. This uses the variant's pin map to determine the Apollo3 pad)
 Uart Serial1(1, 10, 9); // Declares a Uart object called Serial1 using instance 1 of Apollo3 UART peripherals with RX on pin 10 and TX on pin 9 (note, you specify *pins* not Apollo3 pads. This uses the variant's pin map to determine the Apollo3 pad)
+
+// Analog pin numbers
+const ap3_gpio_pin_t ap3_analog_A0 = 0;
+const ap3_gpio_pin_t ap3_analog_A1 = 1;
+const ap3_gpio_pin_t ap3_analog_A2 = 2;
+const ap3_gpio_pin_t ap3_analog_A3 = 3;
+const ap3_gpio_pin_t ap3_analog_A5 = 5;
+const ap3_gpio_pin_t ap3_analog_A14 = 14;
+const ap3_gpio_pin_t ap3_analog_A15 = 15;
+const ap3_gpio_pin_t ap3_analog_A16 = 16;

--- a/variants/redboard_artemis_nano/config/variant.h
+++ b/variants/redboard_artemis_nano/config/variant.h
@@ -47,14 +47,25 @@ extern Uart Serial1;
 #define AP3_SPI_DUP ap3_spi_full_duplex // Specify that SPI is full-duplex (as opposed to ap3_spi_tx_only or ap3_spi_rx_only)
 
 // Mapping of analog pins to digital pins of variant
-#define A0 0
-#define A1 1
-#define A2 2
-#define A3 3
-#define A5 5
-#define A14 14
-#define A15 15
-#define A16 16
+// (this method - aliasing the name of a constant variable - is compatible with the usage of 'AX' names in 'arm_math.h')
+#define A0 ap3_analog_A0
+#define A1 ap3_analog_A1
+#define A2 ap3_analog_A2
+#define A3 ap3_analog_A3
+#define A5 ap3_analog_A5
+#define A14 ap3_analog_A14
+#define A15 ap3_analog_A15
+#define A16 ap3_analog_A16
+
+// Promise the existence of analog pin names
+extern const ap3_gpio_pin_t ap3_analog_A0;
+extern const ap3_gpio_pin_t ap3_analog_A1;
+extern const ap3_gpio_pin_t ap3_analog_A2;
+extern const ap3_gpio_pin_t ap3_analog_A3;
+extern const ap3_gpio_pin_t ap3_analog_A5;
+extern const ap3_gpio_pin_t ap3_analog_A14;
+extern const ap3_gpio_pin_t ap3_analog_A15;
+extern const ap3_gpio_pin_t ap3_analog_A16;
 
 #define LED_BUILTIN 19
 


### PR DESCRIPTION
now 'AX' macros can be expanded in 'arm_math.h' and other included files with relatively low consequence (if the corresponding 'ap3_analog_AX' sybol is used in included files it could be a problem - but hte odds are lowered by using a long descriptive name)