### PR TITLE
add configurable EEPROM length

### DIFF
--- a/libraries/EEPROM/examples/Example2_AllFunctions/Example2_AllFunctions.ino
+++ b/libraries/EEPROM/examples/Example2_AllFunctions/Example2_AllFunctions.ino
@@ -50,12 +50,12 @@ void setup()
   Serial.println("8 bit tests");
   byte myValue1 = 200;
   byte myValue2 = 23;
-  randomLocation = random(0, EEPROM.length());
+  randomLocation = random(0, EEPROM.length() - sizeof(myValue1));
 
   startTime = millis();
   EEPROM.write(randomLocation, myValue1); //(location, data)
   endTime = millis();
-  EEPROM.put(randomLocation + 1, myValue2);
+  EEPROM.put(randomLocation + sizeof(myValue1), myValue2);
 
   Serial.printf("Write byte time: %dms\n", endTime - startTime);
 
@@ -63,12 +63,12 @@ void setup()
   EEPROM.write(randomLocation, myValue1); //(location, data)
   endTime = millis();
 
-  Serial.printf("Write identical byte to same location (should be ~1): %dms\n", endTime - startTime);
+  Serial.printf("Write identical byte to same location: %dms\n", endTime - startTime);
 
   byte response1 = EEPROM.read(randomLocation);
-  byte response2 = EEPROM.read(randomLocation + 1);
+  byte response2 = EEPROM.read(randomLocation + sizeof(myValue1));
   Serial.printf("Location %d should be %d: %d\n\r", randomLocation, myValue1, response1);
-  Serial.printf("Location %d should be %d: %d\n\r", randomLocation + 1, myValue2, response2);
+  Serial.printf("Location %d should be %d: %d\n\r", randomLocation + sizeof(myValue1), myValue2, response2);
   //-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-
 
   Serial.println("");
@@ -78,17 +78,17 @@ void setup()
   //-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-
   uint16_t myValue3 = 3411;
   int16_t myValue4 = -366;
-  randomLocation = random(0, EEPROM.length());
+  randomLocation = random(0, EEPROM.length() - sizeof(myValue3));
 
   EEPROM.put(randomLocation, myValue3);
-  EEPROM.put(randomLocation + 2, myValue4);
+  EEPROM.put(randomLocation + sizeof(myValue3), myValue4);
 
   uint16_t response3;
   int16_t response4;
   EEPROM.get(randomLocation, response3);
-  EEPROM.get(randomLocation + 2, response4);
+  EEPROM.get(randomLocation + sizeof(myValue3), response4);
   Serial.printf("Location %d should be %d: %d\n\r", randomLocation, myValue3, response3);
-  Serial.printf("Location %d should be %d: %d\n\r", randomLocation + 2, myValue4, response4);
+  Serial.printf("Location %d should be %d: %d\n\r", randomLocation + sizeof(myValue3), myValue4, response4);
   //-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-
 
   Serial.println("");
@@ -99,34 +99,34 @@ void setup()
   Serial.printf("Size of int: %d\n", sizeof(int));
   int myValue5 = -245000;
   unsigned int myValue6 = 400123;
-  randomLocation = random(0, EEPROM.length());
+  randomLocation = random(0, EEPROM.length() - sizeof(myValue5));
 
   EEPROM.put(randomLocation, myValue5);
-  EEPROM.put(randomLocation + 4, myValue6);
+  EEPROM.put(randomLocation + sizeof(myValue5), myValue6);
 
   int response5;
   unsigned int response6;
   EEPROM.get(randomLocation, response5);
-  EEPROM.get(randomLocation + 4, response6);
+  EEPROM.get(randomLocation + sizeof(myValue5), response6);
   Serial.printf("Location %d should be %d: %d\n\r", randomLocation, myValue5, response5);
-  Serial.printf("Location %d should be %d: %d\n\r", randomLocation + 4, myValue6, response6);
+  Serial.printf("Location %d should be %d: %d\n\r", randomLocation + sizeof(myValue5), myValue6, response6);
   //-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-
 
   //int32_t and uint32_t sequential test
   //-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-
   int32_t myValue7 = -341002;
   uint32_t myValue8 = 241544;
-  randomLocation = random(0, EEPROM.length());
+  randomLocation = random(0, EEPROM.length() - sizeof(myValue7));
 
   EEPROM.put(randomLocation, myValue7);
-  EEPROM.put(randomLocation + 4, myValue8);
+  EEPROM.put(randomLocation + sizeof(myValue7), myValue8);
 
   int32_t response7;
   uint32_t response8;
   EEPROM.get(randomLocation, response7);
-  EEPROM.get(randomLocation + 4, response8);
+  EEPROM.get(randomLocation + sizeof(myValue7), response8);
   Serial.printf("Location %d should be %d: %d\n\r", randomLocation, myValue7, response7);
-  Serial.printf("Location %d should be %d: %d\n\r", randomLocation + 4, myValue8, response8);
+  Serial.printf("Location %d should be %d: %d\n\r", randomLocation + sizeof(myValue7), myValue8, response8);
   //-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-
 
   //float (32) sequential test
@@ -134,17 +134,17 @@ void setup()
   Serial.printf("Size of float: %d\n", sizeof(float));
   float myValue9 = -7.35;
   float myValue10 = 5.22;
-  randomLocation = random(0, EEPROM.length());
+  randomLocation = random(0, EEPROM.length() - sizeof(myValue9));
 
   EEPROM.put(randomLocation, myValue9);
-  EEPROM.put(randomLocation + 4, myValue10);
+  EEPROM.put(randomLocation + sizeof(myValue9), myValue10);
 
   float response9;
   float response10;
   EEPROM.get(randomLocation, response9);
-  EEPROM.get(randomLocation + 4, response10);
+  EEPROM.get(randomLocation + sizeof(myValue9), response10);
   Serial.printf("Location %d should be %f: %f\n\r", randomLocation, myValue9, response9);
-  Serial.printf("Location %d should be %f: %f\n\r", randomLocation + 4, myValue10, response10);
+  Serial.printf("Location %d should be %f: %f\n\r", randomLocation + sizeof(myValue9), myValue10, response10);
   //-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-
 
   Serial.println("");
@@ -157,24 +157,24 @@ void setup()
   double myValue12 = 384.95734987;
   double myValue13 = 917.14159;
   double myValue14 = 254.8877;
-  randomLocation = random(0, EEPROM.length());
+  randomLocation = random(0, EEPROM.length() - sizeof(myValue11));
 
   startTime = millis();
   EEPROM.put(randomLocation, myValue11);
   endTime = millis();
   Serial.printf("Time to record 64-bits: %dms\n", endTime - startTime);
 
-  EEPROM.put(randomLocation + 8, myValue12);
+  EEPROM.put(randomLocation + sizeof(myValue11), myValue12);
   EEPROM.put(EEPROM.length() - sizeof(myValue13), myValue13); //Test end of EEPROM space
 
   double response11;
   double response12;
   double response13;
   EEPROM.get(randomLocation, response11);
-  EEPROM.get(randomLocation + 8, response12);
+  EEPROM.get(randomLocation + sizeof(myValue11), response12);
   EEPROM.get(EEPROM.length() - sizeof(myValue13), response13);
   Serial.printf("Location %d should be %lf: %lf\n", randomLocation, myValue11, response11);
-  Serial.printf("Location %d should be %lf: %lf\n", randomLocation + 8, myValue12, response12);
+  Serial.printf("Location %d should be %lf: %lf\n", randomLocation + sizeof(myValue11), myValue12, response12);
   Serial.printf("Edge of EEPROM %d should be %lf: %lf\n", EEPROM.length() - sizeof(myValue13), myValue13, response13);
 
   double response14;
@@ -189,7 +189,7 @@ void setup()
   //String write test
   //-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-
   char myString[19] = "How are you today?";
-  randomLocation = random(0, EEPROM.length());
+  randomLocation = random(0, EEPROM.length() - sizeof(myString));
   EEPROM.put(randomLocation, myString);
 
   char readMy[19];

--- a/libraries/EEPROM/examples/Example2_AllFunctions/Example2_AllFunctions.ino
+++ b/libraries/EEPROM/examples/Example2_AllFunctions/Example2_AllFunctions.ino
@@ -23,6 +23,12 @@
 
 void setup()
 {
+  // You may choose to enable more or less EEPROM -
+  // Default length is 1024 bytes (if setLength is not called)
+  EEPROM.setLength(1080); // this would make the length 1080 bytes
+  // EEPROM.setLength(AP3_EEPROM_MAX_LENGTH); // the maximum length is 8192 bytes (AP3_EEPROM_MAX_LENGTH)
+  // Note: larger sizes will increase RAM usage and execution time
+
   Serial.begin(115200);
   Serial.println("EEPROM Examples");
 
@@ -44,7 +50,7 @@ void setup()
   Serial.println("8 bit tests");
   byte myValue1 = 200;
   byte myValue2 = 23;
-  randomLocation = random(0, AP3_FLASH_EEPROM_SIZE);
+  randomLocation = random(0, EEPROM.length());
 
   startTime = millis();
   EEPROM.write(randomLocation, myValue1); //(location, data)
@@ -72,7 +78,7 @@ void setup()
   //-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-
   uint16_t myValue3 = 3411;
   int16_t myValue4 = -366;
-  randomLocation = random(0, AP3_FLASH_EEPROM_SIZE);
+  randomLocation = random(0, EEPROM.length());
 
   EEPROM.put(randomLocation, myValue3);
   EEPROM.put(randomLocation + 2, myValue4);
@@ -93,7 +99,7 @@ void setup()
   Serial.printf("Size of int: %d\n", sizeof(int));
   int myValue5 = -245000;
   unsigned int myValue6 = 400123;
-  randomLocation = random(0, AP3_FLASH_EEPROM_SIZE);
+  randomLocation = random(0, EEPROM.length());
 
   EEPROM.put(randomLocation, myValue5);
   EEPROM.put(randomLocation + 4, myValue6);
@@ -110,7 +116,7 @@ void setup()
   //-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-
   int32_t myValue7 = -341002;
   uint32_t myValue8 = 241544;
-  randomLocation = random(0, AP3_FLASH_EEPROM_SIZE);
+  randomLocation = random(0, EEPROM.length());
 
   EEPROM.put(randomLocation, myValue7);
   EEPROM.put(randomLocation + 4, myValue8);
@@ -128,7 +134,7 @@ void setup()
   Serial.printf("Size of float: %d\n", sizeof(float));
   float myValue9 = -7.35;
   float myValue10 = 5.22;
-  randomLocation = random(0, AP3_FLASH_EEPROM_SIZE);
+  randomLocation = random(0, EEPROM.length());
 
   EEPROM.put(randomLocation, myValue9);
   EEPROM.put(randomLocation + 4, myValue10);
@@ -151,7 +157,7 @@ void setup()
   double myValue12 = 384.95734987;
   double myValue13 = 917.14159;
   double myValue14 = 254.8877;
-  randomLocation = random(0, AP3_FLASH_EEPROM_SIZE);
+  randomLocation = random(0, EEPROM.length());
 
   startTime = millis();
   EEPROM.put(randomLocation, myValue11);
@@ -183,7 +189,7 @@ void setup()
   //String write test
   //-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-
   char myString[19] = "How are you today?";
-  randomLocation = random(0, AP3_FLASH_EEPROM_SIZE);
+  randomLocation = random(0, EEPROM.length());
   EEPROM.put(randomLocation, myString);
 
   char readMy[19];

--- a/libraries/EEPROM/src/EEPROM.h
+++ b/libraries/EEPROM/src/EEPROM.h
@@ -66,9 +66,10 @@
 Error : EEPROM start address must be divisble by 8192
 #endif
 
-        //By limiting EEPROM size to 1024 bytes, we reduce the amount of SRAM required and
-        //time needed to read/write words into flash. It can be increased
-        //to 2048 if needed
+        //Operations on psuedo-EEPROM require a read-write-modify cycle on the entire
+        //configured memory area because flash pages cannot be partially erased. The
+        //larger the memory area the longer this operation will take. Here are some
+        //benchmarks:
         //1024 = 19ms update time
         //2048 = 23ms update time
         const uint16_t AP3_DEFAULT_FLASH_EEPROM_SIZE = 1024; //In bytes
@@ -185,7 +186,7 @@ struct EEPROMClass
   }
   void setLength(uint16_t length)
   {
-    allowedSize = length;
+    allowedSize = (length <= AP3_EEPROM_MAX_LENGTH) ? length : AP3_EEPROM_MAX_LENGTH;
   }
 
   //Functionality to 'get' and 'put' objects to and from EEPROM.

--- a/libraries/EEPROM/src/EEPROM.h
+++ b/libraries/EEPROM/src/EEPROM.h
@@ -60,13 +60,13 @@
 
 #define AP3_FLASH_EEPROM_START 0xFE000
 #define AP3_FLASH_PAGE_SIZE 8192
-#define AP3_EEPROM_MAX_LENGTH AP3_FLASH_PAGE_SIZE
+#define AP3_EEPROM_MAX_LENGTH (AP3_FLASH_PAGE_SIZE - 16)
 
 #if AP3_FLASH_EEPROM_START % AP3_FLASH_PAGE_SIZE
 Error : EEPROM start address must be divisble by 8192
 #endif
 
-        //The size of the EEPROM may be (ptionally) user-configured using the EEPROM.setLength()
+        //The size of the EEPROM may be (optionally) user-configured using the EEPROM.setLength()
         //method. Valid values are in the range [0, AP3_EEPROM_MAX_LENGTH]. Reducing the size of
         //EEPROM will cause data stored in the higher addresses to be lost. The default size is
         //set below. See Example2_AllFunctions for a usage example.

--- a/libraries/EEPROM/src/EEPROM.h
+++ b/libraries/EEPROM/src/EEPROM.h
@@ -66,6 +66,11 @@
 Error : EEPROM start address must be divisble by 8192
 #endif
 
+        //The size of the EEPROM may be (ptionally) user-configured using the EEPROM.setLength()
+        //method. Valid values are in the range [0, AP3_EEPROM_MAX_LENGTH]. Reducing the size of
+        //EEPROM will cause data stored in the higher addresses to be lost. The default size is
+        //set below. See Example2_AllFunctions for a usage example.
+
         //Operations on psuedo-EEPROM require a read-write-modify cycle on the entire
         //configured memory area because flash pages cannot be partially erased. The
         //larger the memory area the longer this operation will take. Here are some


### PR DESCRIPTION
since the flashContent buffer is declared on the stack it may be dynamically sized the user can take advantage of this to allow for any size EEPROM up to the allocated 1 page of flash

- added 'allowedSize' member to EEPROMClass
- added setter for allowedSize 'setLength'
- adjusted 'length' to return allowedSize

- adjusted 'writeBlockToEEPROM' to use the allowedSize of the EEPROM structure when checking flash memory.

- added example usage to Example2_AllFunctions