### PR TITLE
Fix svl script

### DIFF
--- a/tools/artemis/artemis_svl.py
+++ b/tools/artemis/artemis_svl.py
@@ -323,7 +323,7 @@ def main():
 
         print('\n\nArtemis SVL Bootloader')
         if not os.path.exists(args.binfile):
-            print("Bin file {} does not exits.".format(args.binfile))
+            print("Bin file {} does not exist.".format(args.binfile))
             exit()
 
         bl_success = False
@@ -354,7 +354,7 @@ def main():
 
         if(entered_bootloader == False):
             print(
-                "Target failed to enter bootload mode. Verify the right COM port is selected.")
+                "Target failed to enter bootload mode. Verify the right COM port is selected and that your board has the SVL bootloader.")
 
     except serial.SerialException:
         phase_serial_port_help()

--- a/tools/artemis/artemis_svl.py
+++ b/tools/artemis/artemis_svl.py
@@ -42,6 +42,9 @@ import math
 import os.path
 from sys import exit
 
+SCRIPT_VERSION_MAJOR = "1"
+SCRIPT_VERSION_MINOR = "7"
+
 # ***********************************************************************************
 #
 # Commands
@@ -322,6 +325,10 @@ def main():
         num_tries = 3
 
         print('\n\nArtemis SVL Bootloader')
+
+        verboseprint("Script version " + SCRIPT_VERSION_MAJOR +
+                     "." + SCRIPT_VERSION_MINOR)
+
         if not os.path.exists(args.binfile):
             print("Bin file {} does not exist.".format(args.binfile))
             exit()


### PR DESCRIPTION
This adds back serial exception printing.

It also adds a few helper texts:

![image](https://user-images.githubusercontent.com/117102/75587213-365b3380-5a33-11ea-857a-655809ad84e3.png)

Below - when COM is valid but the target fails to respond to the 'enter bootload' command.
![image](https://user-images.githubusercontent.com/117102/75587266-54c12f00-5a33-11ea-8ccd-3902b150ad67.png)

Below - verbose output when COM is valid but target fails to respond:
![image](https://user-images.githubusercontent.com/117102/75587343-77ebde80-5a33-11ea-8278-e5f700f52a9d.png)



