### PR TITLE
Increase performance of UART RX.

### DIFF
--- a/cores/arduino/ard_sup/ap3_uart.h
+++ b/cores/arduino/ard_sup/ap3_uart.h
@@ -30,11 +30,11 @@ SOFTWARE.
 #include "RingBuffer.h"
 
 #ifndef AP3_UART_RINGBUFF_SIZE
-#define AP3_UART_RINGBUFF_SIZE 256
+#define AP3_UART_RINGBUFF_SIZE 256 * 16
 #endif
 
 #ifndef AP3_UART_LINBUFF_SIZE
-#define AP3_UART_LINBUFF_SIZE 256
+#define AP3_UART_LINBUFF_SIZE 256 * 16
 #endif
 
 typedef RingBufferN<AP3_UART_RINGBUFF_SIZE> AP3UartRingBuffer;
@@ -78,7 +78,7 @@ public:
 	operator bool() { return true; } // todo: wait for a serial terminal to be open... probably depends on RTS or CTS...
 
 private:
-public:													//temporary
+public:							  //temporary
 	AP3UartRingBuffer _rx_buffer; // These buffers guarantee the lifespan of the data to transmit
 	AP3UartRingBuffer _tx_buffer; //		to allow for asynchronous tranfsers
 

--- a/cores/arduino/ard_sup/uart/ap3_uart.cpp
+++ b/cores/arduino/ard_sup/uart/ap3_uart.cpp
@@ -543,19 +543,16 @@ inline void Uart::uart_isr(void)
             {
                 .ui32Direction = AM_HAL_UART_READ,
                 .pui8Data = (uint8_t *)&rx_c,
-                .ui32NumBytes = 1,
+                .ui32NumBytes = sizeof(rx_c),
                 .ui32TimeoutMs = 0,
                 .pui32BytesTransferred = &ui32BytesRead,
             };
 
-        do
+        am_hal_uart_transfer(_handle, &sRead);
+        if (ui32BytesRead)
         {
-            am_hal_uart_transfer(_handle, &sRead);
-            if (ui32BytesRead)
-            {
-                _rx_buffer.store_char(rx_c);
-            }
-        } while (ui32BytesRead);
+            _rx_buffer.store_char(rx_c);
+        }
     }
 }
 


### PR DESCRIPTION
This PR

* Increases the UART buffers from 256 * 4 (TX/RX for UART0 and UART1) to 4096 * 4
* Removes the loop within the RX ISR
* These changes allow Artemis to receive full speed 460800bps without dropping bytes

We are only doing single byte reads from the UART FIFO. By calling am_hal_uart_transfer multiple times it increases the ISR time.

Original timing:
![image](https://user-images.githubusercontent.com/117102/77010524-90169580-692f-11ea-958f-a46cbf8c92b9.png)

Timing after this PR:

![image](https://user-images.githubusercontent.com/117102/77010560-a0c70b80-692f-11ea-89db-0f98dbb474e4.png)

You can see the ISR becomes shorter and more repetitive. 

FWIW - With burst mode turned on, ISR drops even more to 8.5us so 921600bps may be possible.

For reference:
* How big is RX FIFO within HAL? 32 bytes
* Is there a 'nearly full' interrupt for the RX FIFO? No
* We could check the RX FIFO empty bit in the ISR in a loop but this is basically skirting the HAL layer. I've attempted this without much luck.
* We could increase the ISR priority level but we haven't done this for any ISRs in the core, yet, so I'm not sure if we want to.

This PR attempts to strike a balance between RAM footprint (what's and extra 15k between friends?) and increase serial performance.





