### PR TITLE
fix extern declaration of analog channel and config maps

### DIFF
--- a/cores/arduino/ard_sup/ap3_analog.h
+++ b/cores/arduino/ard_sup/ap3_analog.h
@@ -30,8 +30,8 @@ SOFTWARE.
 #define AP3_USE_DEFAULT_TIMER_NUM (0xFF)
 
 extern const ap3_analog_pad_map_elem_t ap3_analog_map[AP3_ANALOG_PADS];
-extern const ap3_analog_channel_map_elem_t ap3_analog_channel_map[AP3_ANALOG_PADS];
-extern ap3_analog_configure_map_elem_t ap3_analog_configure_map[AP3_ANALOG_PADS];
+extern const ap3_analog_channel_map_elem_t ap3_analog_channel_map[AP3_ANALOG_CHANNELS];
+extern ap3_analog_configure_map_elem_t ap3_analog_configure_map[AP3_ANALOG_CHANNELS];
 
 // ADC Device Handle.
 static void *g_ADCHandle;


### PR DESCRIPTION
Fixes #143 but can't explain precisely why - probably compiler specification magic. Not to mention that there was an honest error in the codebase.