### PR TITLE
Digital w after analog fix

### DIFF
--- a/cores/arduino/ard_sup/gpio/ap3_gpio.cpp
+++ b/cores/arduino/ard_sup/gpio/ap3_gpio.cpp
@@ -14,7 +14,7 @@ uint8_t gpio_num_isr = 0;
 //*****************************************************************************
 //  Local function declarations
 //*****************************************************************************
-uint32_t ap3_get_funct_sel(ap3_gpio_pad_t pad);
+static inline uint32_t ap3_get_funct_sel(ap3_gpio_pad_t pad);
 
 //*****************************************************************************
 //  Local defines.
@@ -151,7 +151,7 @@ extern void digitalWrite(uint8_t pin, uint8_t val)
     }
 }
 
-uint32_t ap3_get_funct_sel(ap3_gpio_pad_t pad)
+static inline uint32_t ap3_get_funct_sel(ap3_gpio_pad_t pad)
 {
     uint32_t padregAddr = AM_REGADDR(GPIO, PADREGA) + (pad & ~0x3);
     uint32_t padShft = ((pad & 0x3) << 3);

--- a/cores/arduino/ard_sup/gpio/ap3_gpio.cpp
+++ b/cores/arduino/ard_sup/gpio/ap3_gpio.cpp
@@ -35,7 +35,6 @@ static inline uint32_t ap3_get_funct_sel(ap3_gpio_pad_t pad);
 //Additional Defines
 #define PADREG_FNSEL_Msk 0x38
 #define GPIO_FUNCTION 3
-#
 
 ap3_gpio_pad_t ap3_gpio_pin2pad(ap3_gpio_pin_t pin)
 {
@@ -136,10 +135,6 @@ extern void digitalWrite(uint8_t pin, uint8_t val)
     if (!ap3_gpio_is_valid(pad))
     {
         return;
-    }
-    if (ap3_get_funct_sel(pad) != GPIO_FUNCTION)
-    {
-        pinMode(pin, OUTPUT);
     }
     if (val)
     {

--- a/cores/arduino/ard_sup/gpio/ap3_gpio.cpp
+++ b/cores/arduino/ard_sup/gpio/ap3_gpio.cpp
@@ -12,11 +12,16 @@ ap3_gpio_isr_entry_t gpio_isr_entries[AP3_GPIO_MAX_PADS] = {NULL};
 uint8_t gpio_num_isr = 0;
 
 //*****************************************************************************
-//  Local defines. Copied from am_hal_gpio.c
+//  Local function declarations
+//*****************************************************************************
+uint32_t ap3_get_funct_sel(ap3_gpio_pad_t pad);
+
+//*****************************************************************************
+//  Local defines.
 //*****************************************************************************
 //
 // Generally define GPIO PADREG and GPIOCFG bitfields
-//
+// Copied from am_hal_gpio.c
 #define PADREG_FLD_76_S 6
 #define PADREG_FLD_FNSEL_S 3
 #define PADREG_FLD_DRVSTR_S 2
@@ -26,6 +31,11 @@ uint8_t gpio_num_isr = 0;
 #define GPIOCFG_FLD_INTD_S 3
 #define GPIOCFG_FLD_OUTCFG_S 1
 #define GPIOCFG_FLD_INCFG_S 0
+
+//Additional Defines
+#define PADREG_FNSEL_Msk 0x38
+#define GPIO_FUNCTION 3
+#
 
 ap3_gpio_pad_t ap3_gpio_pin2pad(ap3_gpio_pin_t pin)
 {
@@ -76,32 +86,34 @@ void padMode(uint8_t pad, am_hal_gpio_pincfg_t mode)
 }
 
 // translate Arduino style pin mode function to apollo3 implementation
-void pinMode(uint8_t pin, uint8_t mode) {
+void pinMode(uint8_t pin, uint8_t mode)
+{
 
     am_hal_gpio_pincfg_t pinmode = AP3_GPIO_PINCFG_NULL;
 
-    switch (mode) {
-        case INPUT:
-            pinmode = AP3_PINCFG_INPUT;
-            break;
-        case OUTPUT:
-            pinmode = AP3_PINCFG_OUTPUT;
-            break;
-        case INPUT_PULLUP:
-            pinmode = AP3_PINCFG_INPUT_PULLUP;
-            break;
-        case INPUT_PULLDOWN:
-            pinmode = AP3_PINCFG_INPUT_PULLDOWN;
-            break;
-        case OPEN_DRAIN:
-            pinmode = AP3_PINCFG_OPEN_DRAIN;
-            break;
-        case TRISTATE:
-            pinmode = AP3_PINCFG_TRISTATE;
-            break;
-        default:
-            //no match, just do nothing
-            return;
+    switch (mode)
+    {
+    case INPUT:
+        pinmode = AP3_PINCFG_INPUT;
+        break;
+    case OUTPUT:
+        pinmode = AP3_PINCFG_OUTPUT;
+        break;
+    case INPUT_PULLUP:
+        pinmode = AP3_PINCFG_INPUT_PULLUP;
+        break;
+    case INPUT_PULLDOWN:
+        pinmode = AP3_PINCFG_INPUT_PULLDOWN;
+        break;
+    case OPEN_DRAIN:
+        pinmode = AP3_PINCFG_OPEN_DRAIN;
+        break;
+    case TRISTATE:
+        pinmode = AP3_PINCFG_TRISTATE;
+        break;
+    default:
+        //no match, just do nothing
+        return;
     }
 
     pinMode(pin, pinmode);
@@ -125,6 +137,10 @@ extern void digitalWrite(uint8_t pin, uint8_t val)
     {
         return;
     }
+    if (ap3_get_funct_sel(pad) != GPIO_FUNCTION)
+    {
+        pinMode(pin, OUTPUT);
+    }
     if (val)
     {
         am_hal_gpio_output_set(ap3_gpio_pin2pad(pin));
@@ -133,6 +149,16 @@ extern void digitalWrite(uint8_t pin, uint8_t val)
     {
         am_hal_gpio_output_clear(ap3_gpio_pin2pad(pin));
     }
+}
+
+uint32_t ap3_get_funct_sel(ap3_gpio_pad_t pad)
+{
+    uint32_t padregAddr = AM_REGADDR(GPIO, PADREGA) + (pad & ~0x3);
+    uint32_t padShft = ((pad & 0x3) << 3);
+    uint32_t functSelShift = PADREG_FLD_FNSEL_S;
+    uint32_t functSelMask = PADREG_FNSEL_Msk;
+
+    return (((AM_REGVAL(padregAddr) >> padShft) & functSelMask) >> functSelShift);
 }
 
 extern int digitalRead(uint8_t pin)


### PR DESCRIPTION
Add a check in digital write to see if the pin is not longer configured for GPIO, and change it back if needed.

This allows a DigitalWrite to follow an AnalogWrite, which is consistent with the behavior some user may expect.