### PR TITLE
Corrected the pads for SDA2 and SCL2 on the Nano

### DIFF
--- a/variants/redboard_artemis_nano/config/variant.cpp
+++ b/variants/redboard_artemis_nano/config/variant.cpp
@@ -42,8 +42,8 @@ const ap3_gpio_pad_t ap3_variant_pinmap[AP3_VARIANT_NUM_PINS] = {
     35, //A14 - ~TX1/I2SDAT/PDMCLK
     32, //A15 - ~SCCIO
     12, //A16 - ~PDMCLK/TX1
-    32, //17 - ~SDA2/MISO3/RX1
-    12, //18 - ~SCL2/SCK2
+    25, //17 - ~SDA2/MISO2/RX1
+    27, //18 - ~SCL2/SCK2
     19, //19 - ~Not exposed, Status LED
     48, //20 - Not exposed, TX0
     49, //21 - Not exposed, RX0


### PR DESCRIPTION
Hi Nathan (@nseidle ) / Owen (@oclyke),
I noticed a gremlin in the pin to pad mappings for the Artemis Nano. Pads 32 and 12 were allocated twice:
https://github.com/sparkfun/Arduino_Apollo3/blob/master/variants/redboard_artemis_nano/config/variant.cpp#L43-L46
Please check if this PR is valid, because (a) I don't have a Nano and (b) surely this means the Nano Qwiic port doesn't work at the moment?
Cheers,
Paul