### PR TITLE
patch full duplex SPI transfers...

### DIFF
--- a/cores/arduino/ard_sup/ap3_iomaster_types.h
+++ b/cores/arduino/ard_sup/ap3_iomaster_types.h
@@ -35,4 +35,6 @@ typedef enum{
     AP3_IOM_PAD_TYPES_NUM,
 }ap3_iom_pad_type_e;
 
+#define AM_HAL_IOM_FULLDUPLEX (3) // providing this symbol to recover SPI FULLDUPLEX capabilities within SDK 2.4.2
+
 #endif // _AP3_IOM_TYPES_H_

--- a/libraries/SPI/src/SPI.cpp
+++ b/libraries/SPI/src/SPI.cpp
@@ -280,6 +280,10 @@ void SPIClass::transferOut(void *buf, size_t count)
   _transfer(buf, NULL, count);
 }
 
+void SPIClass::transferOutIn(void* buf_out, void* buf_in, size_t count){
+  _transfer(buf_out, buf_in, count);
+}
+
 void SPIClass::transferIn(void *buf, size_t count)
 {
   _transfer(NULL, buf, count);
@@ -291,13 +295,12 @@ void SPIClass::_transfer(void *buf_out, void *buf_in, size_t count)
   iomTransfer.pui32TxBuffer = (uint32_t *)buf_out; // todo: does this have the proper lifetime?
   iomTransfer.pui32RxBuffer = (uint32_t *)buf_in;
 
-  // // Determine direction
-  // if ((buf_out != NULL) && (buf_in != NULL))
-  // {
-  //   iomTransfer.eDirection = AM_HAL_IOM_FULLDUPLEX;
-  // }
-  // else 
-  if (buf_out != NULL)
+  // Determine direction
+  if ((buf_out != NULL) && (buf_in != NULL))
+  {
+    iomTransfer.eDirection = (am_hal_iom_dir_e)AM_HAL_IOM_FULLDUPLEX;
+  }
+  else if (buf_out != NULL)
   {
     iomTransfer.eDirection = AM_HAL_IOM_TX;
   }
@@ -307,20 +310,20 @@ void SPIClass::_transfer(void *buf_out, void *buf_in, size_t count)
   }
 
   uint32_t retVal32 = 0;
-  // if (iomTransfer.eDirection == AM_HAL_IOM_FULLDUPLEX)
-  // {
-  //   retVal32 = am_hal_iom_spi_blocking_fullduplex(_handle, &iomTransfer);
-  // }
-  // else
-  // {
+  if (iomTransfer.eDirection == AM_HAL_IOM_FULLDUPLEX)
+  {
+    retVal32 = am_hal_iom_spi_blocking_fullduplex(_handle, &iomTransfer);
+  }
+  else
+  {
     retVal32 = am_hal_iom_blocking_transfer(_handle, &iomTransfer);
-  // }
+  }
 
-  // if (retVal32 != 0)
-  // {
-  //   Serial.printf("got an error on _transfer: %d\n", retVal32);
-  //   return retVal32;
-  // }
+  if (retVal32 != 0)
+  {
+    Serial.printf("got an error on _transfer: %d\n", retVal32);
+    // return retVal32;
+  }
 }
 
 void SPIClass::attachInterrupt()

--- a/libraries/SPI/src/SPI.h
+++ b/libraries/SPI/src/SPI.h
@@ -98,6 +98,7 @@ public:
   void transfer(void *buf, size_t count);
   void transferOut(void *buf, size_t count);
   void transferIn(void *buf, size_t count);
+  void transferOutIn(void* buf_out, void* buf_in, size_t count);
 
   // Transaction Functions
   void usingInterrupt(int interruptNumber);


### PR DESCRIPTION
...after migration to AmbiqSuite SDK 2.4.2 HAL

Copied functionality from 2.2.0 version of HAL. Will ultimately want to fix this. Tested with this sketch:

``` c
#include "SPI.h"
#define CS_PIN 13
SPISettings MySPISettings(14000000, MSBFIRST, SPI_MODE0);

/////////////////////////////////////////////
// Set TX and RX values for various data types
uint8_t tx_val_8 = 0xAA;
uint8_t rx_val_8 = 0x00;

uint16_t tx_val_16 = 0xABBA;
uint16_t rx_val_16 = 0x00;

const uint8_t msg_len = 8;
uint8_t tx_msg[msg_len] = {'H', 'e', 'l', 'l', 'o', '!', '!', 0};
uint8_t rx_msg[msg_len] = {0, 0, 0, 0, 0, 0, 0, 0};

uint8_t single_buff[msg_len] = {'t', 'e', 's', 't', ' ', 'p', 'a', 't'};
uint8_t single_buff_copy[msg_len] = {0, 0, 0, 0, 0, 0, 0, 0};

/////////////////////////////////////////////
// Main test
void setup() {
  Serial.begin(115200);
  SPI.begin();
  pinMode(CS_PIN, OUTPUT);
  digitalWrite(CS_PIN, HIGH);
  memcpy(single_buff_copy, single_buff, msg_len); // copy single buff for comparison after the fact

  delay(100);
  Serial.println("\n\nApollo3 SPI Full Duplex Test Sketch\n");

  /////////////////////////////////////////////
  // SPI Transaction with tests of each data type transfer (connect MOSI to MISO)
  SPI.beginTransaction(MySPISettings);
  digitalWrite(CS_PIN, LOW);

  rx_val_8 = SPI.transfer(tx_val_8);            // test 8-bit fullduplex  (Arduino API)
  rx_val_16 = SPI.transfer16(tx_val_16);        // test 16-bit fullduplex (Arduino API)
  SPI.transferOutIn(tx_msg, rx_msg, msg_len);   // test buffer fullduplex (API extension - shows HW capability)
  SPI.transfer(single_buff, msg_len);           // test out/in in-place   (Arduino API)

  digitalWrite(CS_PIN, HIGH);
  SPI.endTransaction();

  /////////////////////////////////////////////
  // Check if received values match sent values
  Serial.print("SPI.transfer(uint8_t); RESULT: "); test_8bit_match();
  Serial.print("SPI.transfer16(uint16_t); RESULT: "); test_16bit_match();
  Serial.print("SPI.transferOutIn(void*, void*, size_t); RESULT: "); test_msg_match(tx_msg, rx_msg, msg_len);
  Serial.print("SPI.transfer(void*, size_t); RESULT: "); test_msg_match(single_buff_copy, single_buff, msg_len);

  Serial.println();
}

void loop() {
}

void test_8bit_match( void ){
  if(rx_val_8 != tx_val_8){
    Serial.printf("Error: failed fullduplex\n\tSent 0x%02X, received 0x%02X\n", tx_val_8, rx_val_8);
  }else{
    Serial.printf("Passed!\n");
  }
}

void test_16bit_match( void ){
  if(rx_val_16 != tx_val_16){
    Serial.printf("Error: failed fullduplex\n\tSent 0x%04X, received 0x%04X\n", tx_val_16, rx_val_16);
  }else{
    Serial.printf("Passed!\n");
  }
}

void test_msg_match( uint8_t* tx, uint8_t* rx, size_t len ){
  bool msg_match = true;
  for(uint8_t ix = 0; ix < len; ix++){
    if(tx[ix] != rx[ix]){
      msg_match = false;
      break;
    }
  }
  if(!msg_match){
    Serial.printf("Error: failed fullduplex\n\tSent: { ");
    for(uint8_t ix = 0; ix < len; ix++){
      if(ix != 0){
        Serial.print(", ");
      }
      Serial.print((char)tx[ix]);
    }
    Serial.print("}, recieved { ");
    for(uint8_t ix = 0; ix < len; ix++){
      if(ix != 0){
        Serial.print(", ");
      }
      Serial.print((char)rx[ix]);
    }
    Serial.print("}\n");
  }else{
    Serial.printf("Passed!\n");
  }
}
```