### PR TITLE
Low Power examples: added extra Serial prints just before the TX&RX pins are disabled

### DIFF
--- a/libraries/Examples/examples/Advanced/LowPower/LowPower.ino
+++ b/libraries/Examples/examples/Advanced/LowPower/LowPower.ino
@@ -63,6 +63,9 @@ void setup()
   // These two GPIOs are critical: the TX/RX connections between the Artemis module and the CH340S on the Blackboard
   // are prone to backfeeding each other. To stop this from happening, we must reconfigure those pins as GPIOs
   // and then disable them completely:
+  Serial.println("The TX and RX pins need to be disabled to minimize the current draw.");
+  Serial.println("You should not see any more Serial messages after this...");
+  delay(100);
   am_hal_gpio_pinconfig(48 /* TXO-0 */, g_AM_HAL_GPIO_DISABLE);
   am_hal_gpio_pinconfig(49 /* RXI-0 */, g_AM_HAL_GPIO_DISABLE);
 

--- a/libraries/Examples/examples/Advanced/LowPower_WithWake/LowPower_WithWake.ino
+++ b/libraries/Examples/examples/Advanced/LowPower_WithWake/LowPower_WithWake.ino
@@ -56,6 +56,9 @@ void setup()
     // These two GPIOs are critical: the TX/RX connections between the Artemis module and the CH340S on the Blackboard
     // are prone to backfeeding each other. To stop this from happening, we must reconfigure those pins as GPIOs
     // and then disable them completely:
+    Serial.println("The TX and RX pins need to be disabled to minimize the current draw.");
+    Serial.println("You should not see any more Serial messages after this...");
+    delay(100);
     am_hal_gpio_pinconfig(48 /* TXO-0 */, g_AM_HAL_GPIO_DISABLE);
     am_hal_gpio_pinconfig(49 /* RXI-0 */, g_AM_HAL_GPIO_DISABLE);
 


### PR DESCRIPTION
Hi Owen,
I've added extra Serial prints and delays to the LowPower and LowPower_WithWake examples.
(I've left the others well alone!)
All the best,
Paul