### PR TITLE
use recipe.size.regex.data to compute static memory usage

### DIFF
--- a/platform.txt
+++ b/platform.txt
@@ -118,8 +118,7 @@ recipe.objcopy.bin.pattern="{compiler.path}/{compiler.cmd.axf2bin}" {compiler.fl
 ## Compute size
 recipe.size.pattern="{compiler.path}/{compiler.cmd.size}" -A "{build.path}/{build.project_name}.axf"
 recipe.size.regex=\.text\s+([0-9]+).*
-
-recipe.hooks.objcopy.postobjcopy.0.pattern="{compiler.path}/{compiler.cmd.size}" -A "{build.path}/{build.project_name}.axf"
+recipe.size.regex.data=^(?:\.data|\.bss)\s+([0-9]+).*
 
 ## Preprocessor
 preproc.macros.flags=-w -x c++ -E -CC


### PR DESCRIPTION
Closes #121 using the more standard Arduino method

Unfortunately this trick is poorly documented in the 3rd party hardware specification. You can see an example in the [nRF528x Mbed-OS core's platform.txt](https://github.com/arduino/ArduinoCore-nRF528x-mbedos/blob/master/platform.txt)