### PR TITLE
back to 2018 q4 major version of gcc

### DIFF
--- a/platform.txt
+++ b/platform.txt
@@ -63,7 +63,7 @@ defines.variant={build.defs}
 
 
 ## Compiler and Toolchain
-compiler.path={runtime.tools.arm-none-eabi-gcc-7-2017q4.path}/bin
+compiler.path={runtime.tools.arm-none-eabi-gcc-8-2018-q4-major.path}/bin
 compiler.cmd.cpp=arm-none-eabi-g++
 compiler.cmd.c=arm-none-eabi-gcc
 compiler.cmd.S=arm-none-eabi-gcc


### PR DESCRIPTION
somehow [this commit](https://github.com/sparkfun/Arduino_Apollo3/commit/d6997accf6f4b57908aaa6f46a0200abefe8a725) was lost and this is meant to restore it
