### PR TITLE
v1.1.1

### DIFF
--- a/cores/arduino/ard_sup/gpio/ap3_gpio.cpp
+++ b/cores/arduino/ard_sup/gpio/ap3_gpio.cpp
@@ -320,6 +320,7 @@ extern void detachInterrupt(uint8_t pin)
     gpio_isr_entries[gpio_num_isr].callback = NULL;
     gpio_isr_entries[gpio_num_isr].mode = LOW;
     gpio_isr_entries[gpio_num_isr].arg = NULL;
+    gpio_num_isr--;
 }
 
 uint32_t ap3_gpio_enable_interrupts(uint32_t ui32Pin, uint32_t eIntDir)

--- a/platform.txt
+++ b/platform.txt
@@ -63,7 +63,7 @@ defines.variant={build.defs}
 
 
 ## Compiler and Toolchain
-compiler.path={runtime.tools.arm-none-eabi-gcc-7-2017q4.path}/bin
+compiler.path={runtime.tools.arm-none-eabi-gcc-8-2018-q4-major.path}/bin
 compiler.cmd.cpp=arm-none-eabi-g++
 compiler.cmd.c=arm-none-eabi-gcc
 compiler.cmd.S=arm-none-eabi-gcc


### PR DESCRIPTION
This is a release meant to quickly fix the compiler version to allow float printing while we try to sort out the issues with TensorFlow example compilation