### PR TITLE
Add test-compile

### DIFF
--- a/.github/workflows/TestCompile.yml
+++ b/.github/workflows/TestCompile.yml
@@ -1,0 +1,87 @@
+# TestCompile.yml
+# Github workflow script to test compile all examples of an Arduino library repository.
+#
+# Copyright (C) 2020  Armin Joachimsmeyer
+# https://github.com/ArminJo/Github-Actions
+#
+
+# This is the name of the workflow, visible on GitHub UI.
+name: TestCompile
+on:  
+  push: # see: https://help.github.com/en/actions/reference/events-that-trigger-workflows#pull-request-event-pull_request
+    paths:
+    - '**.ino'
+    - '**.cpp'
+    - '**.h'
+    - '**TestCompile.yml'
+  pull_request:
+jobs:
+  build:
+    name: Test compiling examples for Digispark
+    runs-on: ubuntu-18.04
+    env:
+      # Comma separated list without double quotes around the list. 
+      REQUIRED_LIBRARIES: SparkFun MS5637 Barometric Pressure Library,SparkFun MMA8452Q Accelerometer
+      PLATFORM_DEFAULT_URL: https://raw.githubusercontent.com/sparkfun/Arduino_Boards/master/IDE_Board_Manager/package_sparkfun_index.json
+
+    strategy:
+      matrix:
+        # The matrix will produce one job for each configuration parameter of type `arduino-boards-fqbn`
+        # In the Arduino IDE, the fqbn is printed in the first line of the verbose output for compilation as parameter -fqbn=... for the "arduino-builder -dump-prefs" command
+        #
+        # Examples: arduino:avr:uno, arduino:avr:leonardo, arduino:avr:nano, arduino:avr:mega
+        # arduino:sam:arduino_due_x, arduino:samd:arduino_zero_native"
+        # ATTinyCore:avr:attinyx5:chip=85,clock=1internal, digistump:avr:digispark-tiny, digistump:avr:digispark-pro
+        # STM32:stm32:GenF1:pnum=BLUEPILL_F103C8
+        # esp8266:esp8266:huzzah:eesz=4M3M,xtal=80, esp32:esp32:featheresp32:FlashFreq=80
+        # You may add a suffix behind the fqbn with "|" to specify one board for e.g. different compile options like arduino:avr:uno|trace
+        #############################################################################################################
+        arduino-boards-fqbn:
+          - SparkFun:apollo3:artemis
+          - SparkFun:apollo3:amap3redboard
+          - SparkFun:apollo3:amap3nano
+          - SparkFun:apollo3:amap3atp
+          - SparkFun:apollo3:amap3thing
+          - SparkFun:apollo3:edge
+          - SparkFun:apollo3:edge2
+
+
+        # Specify parameters for each board.
+        # With examples-exclude you may exclude specific examples for a board. Use a comma separated list.
+        #############################################################################################################
+        include:
+          - arduino-boards-fqbn: SparkFun:apollo3:artemis
+            examples-exclude: Example4_analogRead,LowPower_WithWork,Example2_Serial,Example2_MoreSPIPorts,Example6_19servos,Example7_29servos
+
+          - arduino-boards-fqbn: SparkFun:apollo3:amap3redboard
+            examples-exclude: Example2_MoreSPIPorts
+
+          - arduino-boards-fqbn: SparkFun:apollo3:amap3nano
+            examples-exclude: Example6_19servos,Example7_29servos
+
+          - arduino-boards-fqbn: SparkFun:apollo3:amap3atp
+            examples-exclude: Example4_analogRead,Example6_19servos
+
+          - arduino-boards-fqbn: SparkFun:apollo3:amap3thing
+
+          - arduino-boards-fqbn: SparkFun:apollo3:edge
+            examples-exclude: Example4_analogRead,LowPower_WithWork,Example2_Serial,Example6_19servos,Example7_29servos
+
+          - arduino-boards-fqbn: SparkFun:apollo3:edge2
+            examples-exclude: Example4_analogRead,LowPower_WithWork,Example2_Serial,Example1_SPI,Example6_19servos,Example7_29servos
+
+      # Do not cancel all jobs / architectures if one job fails
+      fail-fast: false    
+    steps:
+      - name: Checkout
+        uses: actions/checkout@master
+
+      - name: Compile all examples
+        uses: ArminJo/arduino-test-compile@v2
+        with:
+          required-libraries: ${{ env.REQUIRED_LIBRARIES }}
+          arduino-board-fqbn: ${{ matrix.arduino-boards-fqbn }}
+          platform-default-url: ${{ env.PLATFORM_DEFAULT_URL }}
+          platform-url: ${{ matrix.platform-url }}
+          examples-exclude: ${{ matrix.examples-exclude }}
+          examples-build-properties: ${{ toJson(matrix.examples-build-properties) }}


### PR DESCRIPTION
Hello Andy,
I thougt you may appeciate to have automated test-compile for all the libraries in the board package 😀 .
Here it is.
I had to add 20 excludes in order to compile successfully. Maybe these examples (or the according variants.h) can be modified to have these examples also compiling successfully for the board.

Or the examples may have an
```
#if defined(ARDUINO_AM_AP3_SFE_BB_ARTEMIS_NANO)
#error This example is not intended to run on the Artemin Nano board
#endif
```
But this can be done later...

This is the complete exclude list, as can be seen in the *TestCompile.yml* file

```
          - arduino-boards-fqbn: SparkFun:apollo3:artemis
            examples-exclude: Example4_analogRead,LowPower_WithWork,Example2_Serial,Example2_MoreSPIPorts,Example6_19servos,Example7_29servos

          - arduino-boards-fqbn: SparkFun:apollo3:amap3redboard
            examples-exclude: Example2_MoreSPIPorts

          - arduino-boards-fqbn: SparkFun:apollo3:amap3nano
            examples-exclude: Example6_19servos,Example7_29servos

          - arduino-boards-fqbn: SparkFun:apollo3:amap3atp
            examples-exclude: Example4_analogRead,Example6_19servos

          - arduino-boards-fqbn: SparkFun:apollo3:edge
            examples-exclude: Example4_analogRead,LowPower_WithWork,Example2_Serial,Example6_19servos,Example7_29servos
          - arduino-boards-fqbn: SparkFun:apollo3:edge2
            examples-exclude: Example4_analogRead,LowPower_WithWork,Example2_Serial,Example1_SPI,Example6_19servos,Example7_29servos
```
Best regards
Armin