### PR TITLE
Fix for sequential PWM pin setting

### DIFF
--- a/cores/arduino/ard_sup/analog/ap3_analog.cpp
+++ b/cores/arduino/ard_sup/analog/ap3_analog.cpp
@@ -538,7 +538,8 @@ ap3_err_t ap3_pwm_output(uint8_t pin, uint32_t th, uint32_t fw, uint32_t clk)
 
     // if timer is running wait for timer value to roll over (will indicate that at least one pulse has been emitted)
     AM_CRITICAL_BEGIN // critical section when reading / writing config registers
-        if (*((uint32_t *)CTIMERADDRn(CTIMER, timer, CTRL0)) & (CTIMER_CTRL0_TMRA0EN_Msk | CTIMER_CTRL0_TMRB0EN_Msk))
+    if ((segment == AM_HAL_CTIMER_TIMERA && *((uint32_t *)CTIMERADDRn(CTIMER, timer, CTRL0)) & (CTIMER_CTRL0_TMRA0EN_Msk)) ||
+        (segment == AM_HAL_CTIMER_TIMERB && *((uint32_t *)CTIMERADDRn(CTIMER, timer, CTRL0)) & (CTIMER_CTRL0_TMRB0EN_Msk)))
     {
         uint32_t current = 0;
         uint32_t last = 0;
@@ -548,11 +549,10 @@ ap3_err_t ap3_pwm_output(uint8_t pin, uint32_t th, uint32_t fw, uint32_t clk)
             current = am_hal_ctimer_read(timer, segment);
         } while (current >= last);
     }
-
     AM_CRITICAL_END // end critical section
 
-        // clear timer (also stops the timer)
-        am_hal_ctimer_clear(timer, segment);
+    // clear timer (also stops the timer)
+    am_hal_ctimer_clear(timer, segment);
 
     // Configure the repeated pulse mode with our clock source
     am_hal_ctimer_config_single(timer,


### PR DESCRIPTION
Fix for issue #192 

What was happening in the original code was pin would be set correctly with an analogWrite(). When the user went to set the 2nd pin, the timer # would be the same and the code would wait for a roll over, even though the segments were different. This would never happen and we hit an infinite loop.

This PR changes it so the roll over is only checked if the user is requesting an analogWrite() to a pin who's timer *and* segment are active. If the segments don't match, don't wait for a rollover.

I've successfully tested on the 30 PWM accessible pins of an ATP. My test sketch is below.

    const int numberOfPWMPins = 32;

    int pwmPin[numberOfPWMPins] = {
    4,  5,  6,  7,  11,
    12, 13, 18, 19, 22,
    23, 24, 25, 26, 27,
    28, 29, 30, 31, 32, //30 is not routed on Artemis module
    33, 35, 37, 39, 42,
    43, 44, 45, 46, 47, //46 is not routed on Artemis module
    48, 49, //Once 48 is set to PWM output, serial output will fail
    };

    void setup()
    {
    Serial.begin(115200);

    while (!Serial);//Wait for user to open terminal window
    Serial.println("SparkFun Arduino Apollo3 PWM Test");

    //Step through each PWM pin assigning a different analog voltage
    #define ANALOG_OUT_RESOLUTION 8
    int pwmMaxValue = pow(2, ANALOG_OUT_RESOLUTION);

    float startValue = 0.1;
    float endValue = 3.2;
    float stepValue = (endValue - startValue) / numberOfPWMPins;

    for (int x = 0 ; x < numberOfPWMPins ; x++)
    {
        int pinNumber = pwmPin[x];
        float outputVoltage = startValue + (stepValue * x);
        int pwmValue = outputVoltage * pwmMaxValue / 3.3;
        analogWrite(pinNumber, pwmValue);

        Serial.print(pinNumber);
        Serial.print(" now outputting: ");
        Serial.print(outputVoltage, 2);
        Serial.println("V");
        Serial.flush();
    }
    }

    void loop()
    {

    }

