### PR TITLE
Add flow control

### DIFF
--- a/cores/arduino/am_sdk_ap3/mcu/apollo3/hal/am_hal_uart.h
+++ b/cores/arduino/am_sdk_ap3/mcu/apollo3/hal/am_hal_uart.h
@@ -172,8 +172,8 @@ am_hal_uart_transfer_t;
 
 // Flow control
 #define AM_HAL_UART_FLOW_CTRL_NONE          0
-#define AM_HAL_UART_FLOW_CTRL_CTS_ONLY      UART_CR_CTSEN_Msk
-#define AM_HAL_UART_FLOW_CTRL_RTS_ONLY      UART_CR_RTSEN_Msk
+#define AM_HAL_UART_FLOW_CTRL_CTS_ONLY      UART0_CR_CTSEN_Msk
+#define AM_HAL_UART_FLOW_CTRL_RTS_ONLY      UART0_CR_RTSEN_Msk
 #define AM_HAL_UART_FLOW_CTRL_RTS_CTS       (UART0_CR_CTSEN_Msk |   \
                                              UART0_CR_RTSEN_Msk)
 // FIFO enable/disable.

--- a/cores/arduino/ard_sup/uart/ap3_uart.cpp
+++ b/cores/arduino/ard_sup/uart/ap3_uart.cpp
@@ -296,6 +296,22 @@ ap3_err_t Uart::set_config(HardwareSerial_Config_e HWSconfig)
         retval = AP3_INVALID_ARG;
         break;
     }
+
+    //Setup flow control
+    _config.ui32FlowControl = AM_HAL_UART_FLOW_CTRL_NONE;
+    if(_pinRTS != AP3_UART_PIN_UNUSED && _pinCTS != AP3_UART_PIN_UNUSED)
+    {
+        _config.ui32FlowControl = AM_HAL_UART_FLOW_CTRL_RTS_CTS;
+    }
+    else if(_pinRTS != AP3_UART_PIN_UNUSED)
+    {
+        _config.ui32FlowControl = AM_HAL_UART_FLOW_CTRL_RTS_ONLY;
+    }
+    else if(_pinCTS != AP3_UART_PIN_UNUSED)
+    {
+        _config.ui32FlowControl = AM_HAL_UART_FLOW_CTRL_CTS_ONLY;
+    }
+
     return retval;
 }
 
@@ -375,7 +391,7 @@ ap3_err_t Uart::_begin(void)
 
     if (_pinRTS != AP3_UART_PIN_UNUSED)
     {
-        retval = ap3_uart_pad_funcsel(_instance, AP3_UART_TX, ap3_gpio_pin2pad(_pinRTS), &funcsel);
+        retval = ap3_uart_pad_funcsel(_instance, AP3_UART_RTS, ap3_gpio_pin2pad(_pinRTS), &funcsel);
         if (retval != AP3_OK)
         {
             return retval;
@@ -391,7 +407,7 @@ ap3_err_t Uart::_begin(void)
 
     if (_pinCTS != AP3_UART_PIN_UNUSED)
     {
-        retval = ap3_uart_pad_funcsel(_instance, AP3_UART_RX, ap3_gpio_pin2pad(_pinCTS), &funcsel);
+        retval = ap3_uart_pad_funcsel(_instance, AP3_UART_CTS, ap3_gpio_pin2pad(_pinCTS), &funcsel);
         if (retval != AP3_OK)
         {
             return retval;


### PR DESCRIPTION
This PR adds flow control support for all UARTs (0 and 1). 

It was fairly straight forward. Below is the test sketch that shows CTS properly working. I haven't devised a succinct way to test RTS (output). 

    Uart SerialTest(1, 25, 12, 10, 17); //Instance, RX, TX, RTS, CTS

    void setup()
    {
    SerialTest.begin(115200);
    SerialTest.println("SerialTest online");
    }

    void loop()
    {
    SerialTest.println("Stop this text by pulling CTS(17) high");
    }