### PR TITLE
Correcting SMPCNT for arbitrary and 1MHz I2C SCK speeds

### DIFF
--- a/cores/arduino/ard_sup/iomaster/ap3_iomaster.c
+++ b/cores/arduino/ard_sup/iomaster/ap3_iomaster.c
@@ -489,7 +489,7 @@ ap3_iom_configure(void *pHandle, am_hal_iom_config_t *psConfig)
                              _VAL2FLD(IOM0_CLKCFG_FSEL, IOM0_CLKCFG_FSEL_HFRC_DIV4) |
                              _VAL2FLD(IOM0_CLKCFG_IOCLKEN, 1);
                 IOMn(ui32Module)->MI2CCFG = _VAL2FLD(IOM0_MI2CCFG_STRDIS, 0)                            |
-                                            _VAL2FLD(IOM0_MI2CCFG_SMPCNT, 0x21)                         |
+                                            _VAL2FLD(IOM0_MI2CCFG_SMPCNT, 3)                            |
                                             _VAL2FLD(IOM0_MI2CCFG_SDAENDLY, 3)                          |
                                             _VAL2FLD(IOM0_MI2CCFG_SCLENDLY, 0)                          |
                                             _VAL2FLD(IOM0_MI2CCFG_MI2CRST, 1)                           |
@@ -539,7 +539,7 @@ ap3_iom_configure(void *pHandle, am_hal_iom_config_t *psConfig)
                             _VAL2FLD(IOM0_CLKCFG_FSEL, fsel_bitvalue) |
                             _VAL2FLD(IOM0_CLKCFG_IOCLKEN, 1);
                 IOMn(ui32Module)->MI2CCFG = _VAL2FLD(IOM0_MI2CCFG_STRDIS, 0)                            |
-                                            _VAL2FLD(IOM0_MI2CCFG_SMPCNT, 0x21)                         |
+                                            _VAL2FLD(IOM0_MI2CCFG_SMPCNT, ((totper / 6) + 1))           |
                                             _VAL2FLD(IOM0_MI2CCFG_SDAENDLY, 3)                          |
                                             _VAL2FLD(IOM0_MI2CCFG_SCLENDLY, 0)                          |
                                             _VAL2FLD(IOM0_MI2CCFG_MI2CRST, 1)                           |


### PR DESCRIPTION
I believe there is a mistake in the Apollo3 datasheet which indicates SMPCNT should be set to 33 for 1MHz SCK speed.
A value of 3 seems much more appropriate, 33 is way too big.
The arbitrary (default) case now uses ```((totper / 6) + 1)``` instead of being hard-coded to 33 too.
