### PR TITLE
Add Print::write to get write(buf, size)

### DIFF
--- a/cores/arduino/ard_sup/ard_supers/HardwareSerial.h
+++ b/cores/arduino/ard_sup/ard_supers/HardwareSerial.h
@@ -68,6 +68,7 @@ class HardwareSerial : public Stream
     virtual int read(void) = 0;
     virtual void flush(void) = 0;
     virtual size_t write(uint8_t) = 0;
+	using Print::write; // pull in write(str) and write(buf, size) from Print
     virtual operator bool() = 0;
 };
 


### PR DESCRIPTION
A few libraries rely on this ability. I don't see any downside to this add. Teensy and Arduino core both have this add.