### PR TITLE
patch support for Arduino SD lib

### DIFF
--- a/variants/SFE_ARTEMIS/variant.h
+++ b/variants/SFE_ARTEMIS/variant.h
@@ -25,4 +25,10 @@
 // UART
 extern UART Serial1;
 
+// temporary patch to support Arduino SD library
+#define SS 0
+#define MOSI SPI_SDO
+#define MISO SPI_SDI
+#define SCK SPI_CLK
+
 #endif // _VARIANT_H_

--- a/variants/SFE_ARTEMIS_ATP/variant.h
+++ b/variants/SFE_ARTEMIS_ATP/variant.h
@@ -25,4 +25,10 @@
 // UART
 extern UART Serial1;
 
+// temporary patch to support Arduino SD library
+#define SS 0
+#define MOSI SPI_SDO
+#define MISO SPI_SDI
+#define SCK SPI_CLK
+
 #endif // _VARIANT_H_

--- a/variants/SFE_ARTEMIS_DK/variant.h
+++ b/variants/SFE_ARTEMIS_DK/variant.h
@@ -30,4 +30,10 @@
 #define VARIANT_Wire_SDA    I2C_SDA
 #define VARIANT_Wire_SCL    I2C_SCL
 
+// temporary patch to support Arduino SD library
+#define SS 0
+#define MOSI SPI_SDO
+#define MISO SPI_SDI
+#define SCK SPI_CLK
+
 #endif // _VARIANT_H_

--- a/variants/SFE_ARTEMIS_MM_PB/variant.h
+++ b/variants/SFE_ARTEMIS_MM_PB/variant.h
@@ -30,7 +30,7 @@
 #define VARIANT_Wire1_SCL   I2C1_SCL
 
 // temporary patch to support Arduino SD library
-#define SS 0
+#define SS SPI_CS
 #define MOSI SPI_SDO
 #define MISO SPI_SDI
 #define SCK SPI_CLK

--- a/variants/SFE_ARTEMIS_MM_PB/variant.h
+++ b/variants/SFE_ARTEMIS_MM_PB/variant.h
@@ -29,4 +29,10 @@
 #define VARIANT_Wire1_SDA   I2C1_SDA
 #define VARIANT_Wire1_SCL   I2C1_SCL
 
+// temporary patch to support Arduino SD library
+#define SS 0
+#define MOSI SPI_SDO
+#define MISO SPI_SDI
+#define SCK SPI_CLK
+
 #endif // _VARIANT_H_

--- a/variants/SFE_ARTEMIS_NANO/variant.h
+++ b/variants/SFE_ARTEMIS_NANO/variant.h
@@ -28,4 +28,10 @@
 // UART
 extern UART Serial1;
 
+// temporary patch to support Arduino SD library
+#define SS 0
+#define MOSI SPI_SDO
+#define MISO SPI_SDI
+#define SCK SPI_CLK
+
 #endif // _VARIANT_H_

--- a/variants/SFE_ARTEMIS_THING_PLUS/variant.h
+++ b/variants/SFE_ARTEMIS_THING_PLUS/variant.h
@@ -25,4 +25,10 @@
 // UART
 extern UART Serial1;
 
+// temporary patch to support Arduino SD library
+#define SS 0
+#define MOSI SPI_SDO
+#define MISO SPI_SDI
+#define SCK SPI_CLK
+
 #endif // _VARIANT_H_


### PR DESCRIPTION
this is a temporary patch for #271
the better fix would be for Arduino to implement an SD lib that has fall-backs that leverage the SPI api or the digital pin functions in that order