### PR TITLE
add getTempDegC

### DIFF
--- a/cores/arduino/sdk/core-extend/AnalogInternal.h
+++ b/cores/arduino/sdk/core-extend/AnalogInternal.h
@@ -33,6 +33,7 @@ int analogReadTemp( void );
 int analogReadVCCDiv3( void );
 int analogReadVSS( void );
 
+float getTempDegC( void );
 float getTempDegF( void );
 float getVCCV( void );
 

--- a/cores/arduino/sdk/core-implement/CommonAnalog.cpp
+++ b/cores/arduino/sdk/core-implement/CommonAnalog.cpp
@@ -52,7 +52,7 @@ ap3_adc_channel_config_t ap3_adc_channel_configs[] = {
     { 0,    AP3_ADC_INTERNAL_CHANNELS_VSS,      AM_HAL_ADC_SLOT_CHSEL_VSS,      0,                          },
 };
 
-float getTempDegF( void ) {
+float getTempDegC( void ) {
     const float v_ref = 2.0;
     uint16_t counts = analogReadTemp();
 
@@ -72,6 +72,11 @@ float getTempDegF( void ) {
     MBED_ASSERT(ui32Retval == AM_HAL_STATUS_SUCCESS);
 
     return fVT[1]; // Get the temperature
+}
+
+float getTempDegF( void ) {
+    float temp_deg_c = getTempDegC();
+    return ((9.0f/5.0f)*temp_deg_c) + 32.0f;
 }
 
 float getVCCV( void ){


### PR DESCRIPTION
fixes #277
actually, the getTempDegF function incorrectly returned the temperature in deg C. This changes the name of that function and adds another function to convert that value to deg F.