### PR TITLE
edit mbed library inclusion to fix weak function defs

### DIFF
--- a/.github/workflows/generate-variants.yml
+++ b/.github/workflows/generate-variants.yml
@@ -29,7 +29,6 @@ jobs:
               {"name": "artemis-thing-plus-lib", "config": {"base": "compile --library --source=mbed-os", "tgt": "SFE_ARTEMIS_THING_PLUS", "tool": "GCC_ARM"}, "user": {"variant": {"name": "ARTEMIS_THING_PLUS", "loc": "variants/SFE_ARTEMIS_THING_PLUS"}}},
               {"name": "edge-lib", "config": {"base": "compile --library --source=mbed-os", "tgt": "SFE_EDGE", "tool": "GCC_ARM"}, "user": {"variant": {"name": "EDGE", "loc": "variants/SFE_EDGE"}}},
               {"name": "edge2-lib", "config": {"base": "compile --library --source=mbed-os", "tgt": "SFE_EDGE2", "tool": "GCC_ARM"}, "user": {"variant": {"name": "EDGE2", "loc": "variants/SFE_EDGE2"}}},
-              {"name": "artemis-mm-pb-lib", "config": {"base": "compile --library --source=mbed-os", "tgt": "SFE_ARTEMIS_MM_PB", "tool": "GCC_ARM"}, "user": {"variant": {"name": "ARTEMIS_MM_PB", "loc": "variants/SFE_ARTEMIS_MM_PB"}}}
             ]
           mbed: |
             {"url": "https://github.com/sparkfun/mbed-os-ambiq-apollo3", "branch": "ambiq-apollo3-arduino"}

--- a/platform.txt
+++ b/platform.txt
@@ -29,7 +29,7 @@ includes.all={includes.core} {includes.mbed} {includes.variant} {includes.extra}
 
 # libraries
 libs.core=-Wl,--whole-archive {archive_file_path} -Wl,--no-whole-archive
-libs.mbed=-Wl,--allow-multiple-definition -Wl,--whole-archive {build.variant.path}/mbed/libmbed-os.a -Wl,--no-whole-archive
+libs.mbed=-Wl,--whole-archive {build.variant.path}/mbed/libmbed-os.a -Wl,--no-whole-archive
 libs.variant={build.libs}
 libs.extra=
 libs.all={libs.core} {libs.mbed} {libs.variant} {libs.extra}

--- a/platform.txt
+++ b/platform.txt
@@ -29,7 +29,7 @@ includes.all={includes.core} {includes.mbed} {includes.variant} {includes.extra}
 
 # libraries
 libs.core=-Wl,--whole-archive {archive_file_path} -Wl,--no-whole-archive
-libs.mbed={build.variant.path}/mbed/libmbed-os.a
+libs.mbed=-Wl,--allow-multiple-definition -Wl,--whole-archive {build.variant.path}/mbed/libmbed-os.a -Wl,--no-whole-archive
 libs.variant={build.libs}
 libs.extra=
 libs.all={libs.core} {libs.mbed} {libs.variant} {libs.extra}


### PR DESCRIPTION
weak functions were being squashed in the library, adding a --whole-archive flag fixes this issue, but introduces a new multiple definitions issue which i am getting around right now by adding the --allow-multiple-definition flag.
