### PR TITLE
add warning flags to blocklist

### DIFF
--- a/tools/config/blocklist.json
+++ b/tools/config/blocklist.json
@@ -12,7 +12,20 @@
         },
         "cxx": {
             "flags": [
-                "-MMD"
+				"-Wvla"
+				"-Wall"
+				"-Wextra"
+				"-Wno-missing-field-initializers"
+				"-Wno-unused-parameter"
+            ]
+        }
+		"c": {
+            "flags": [
+				"-Wvla"
+				"-Wall"
+				"-Wextra"
+				"-Wno-missing-field-initializers"
+				"-Wno-unused-parameter"
             ]
         }
     }


### PR DESCRIPTION
Arduino can control its own warning settings. also removed -MMD from blocklist.