### PR TITLE
Reduce default I2C clock

### DIFF
--- a/libraries/Wire/src/Wire.cpp
+++ b/libraries/Wire/src/Wire.cpp
@@ -10,6 +10,7 @@ arduino::MbedI2C::MbedI2C(int sda, int scl) : _sda(sda), _scl(scl), usedTxBuffer
 void arduino::MbedI2C::begin() {
 	if(!master){
 		master = new mbed::I2C((PinName)_sda, (PinName)_scl);
+		setClock(100000); //Default to 100kHz
 	}
 }
 


### PR DESCRIPTION
The original default was 400kHz. I'm not sure of the root, I believe mbed imposed? But this was causing problems with a lot of libraries that assume 100kHz start. This PR reduces the bus speed to 100kHz.

Original:
![image](https://user-images.githubusercontent.com/117102/107728808-56b7e880-6cac-11eb-971f-df15e35ec039.png)

After PR:
![image](https://user-images.githubusercontent.com/117102/107728741-1c4e4b80-6cac-11eb-9a1d-2675c24f8127.png)


