### PR TITLE
Add improved low-power code and RTC clearInterrupt() function

### DIFF
--- a/libraries/RTC/examples/Example6_LowPower_Alarm/Example6_LowPower_Alarm.ino
+++ b/libraries/RTC/examples/Example6_LowPower_Alarm/Example6_LowPower_Alarm.ino
@@ -1,6 +1,6 @@
 /*
-  Author: Adam Garbo and Nathan Seidle
-  Created: June 3rd, 2020
+  Author: Adam Garbo
+  Created: March 27th, 2021
   License: MIT. See SparkFun Arduino Apollo3 Project for more information
 
   This example demonstrates how to set an RTC alarm and enter deep sleep.
@@ -88,12 +88,10 @@ void goToSleep()
   for (int x = 0 ; x < 50 ; x++)
     am_hal_gpio_pinconfig(x, g_AM_HAL_GPIO_DISABLE);
 
-  //Power down Flash, SRAM, cache
-  am_hal_pwrctrl_memory_deepsleep_powerdown(AM_HAL_PWRCTRL_MEM_CACHE); // Turn off CACHE
-  am_hal_pwrctrl_memory_deepsleep_powerdown(AM_HAL_PWRCTRL_MEM_FLASH_512K); // Turn off everything but lower 512k
-  am_hal_pwrctrl_memory_deepsleep_powerdown(AM_HAL_PWRCTRL_MEM_SRAM_64K_DTCM); // Turn off everything but lower 64k
-  //am_hal_pwrctrl_memory_deepsleep_powerdown(AM_HAL_PWRCTRL_MEM_ALL); //Turn off all memory (doesn't recover)
-
+  //Power down flash, SRAM, cache
+  am_hal_pwrctrl_memory_deepsleep_powerdown(AM_HAL_PWRCTRL_MEM_ALL); // Power down all cache and flash (~110 uA)
+  am_hal_pwrctrl_memory_deepsleep_retain(AM_HAL_PWRCTRL_MEM_SRAM_384K); // Retain all SRAM (~0.6 uA)
+  
   // Keep the 32kHz clock running for RTC
   am_hal_stimer_config(AM_HAL_STIMER_CFG_CLEAR | AM_HAL_STIMER_CFG_FREEZE);
   am_hal_stimer_config(AM_HAL_STIMER_XTAL_32KHZ);
@@ -107,9 +105,6 @@ void goToSleep()
 // Power up gracefully
 void wakeUp()
 {
-  // Power up SRAM, turn on entire Flash
-  am_hal_pwrctrl_memory_deepsleep_powerdown(AM_HAL_PWRCTRL_MEM_MAX);
-
   // Go back to using the main clock
   am_hal_stimer_config(AM_HAL_STIMER_CFG_CLEAR | AM_HAL_STIMER_CFG_FREEZE);
   am_hal_stimer_config(AM_HAL_STIMER_HFRC_3MHZ);

--- a/libraries/RTC/keywords.txt
+++ b/libraries/RTC/keywords.txt
@@ -24,6 +24,7 @@ setAlarm	KEYWORD2
 setAlarmMode	KEYWORD2
 attachInterrupt	KEYWORD2
 detachInterrupt	KEYWORD2
+clearInterrupt	KEYWORD2
 
 weekday	KEYWORD2
 textWeekday	KEYWORD2

--- a/libraries/RTC/src/RTC.cpp
+++ b/libraries/RTC/src/RTC.cpp
@@ -213,6 +213,11 @@ void APM3_RTC::detachInterrupt()
   am_hal_rtc_int_disable(AM_HAL_RTC_INT_ALM);
 }
 
+void Apollo3RTC::clearInterrupt() {
+  // Clear the RTC alarm interrupt
+  am_hal_rtc_int_clear(AM_HAL_RTC_INT_ALM);
+}
+
 // mthToIndex() converts a string indicating a month to an index value.
 // The return value is a value 0-12, with 0-11 indicating the month given
 // by the string, and 12 indicating that the string is not a month.

--- a/libraries/RTC/src/RTC.h
+++ b/libraries/RTC/src/RTC.h
@@ -21,6 +21,7 @@ public:
   void setAlarmMode(uint8_t mode); //Set the RTC alarm repeat interval
   void attachInterrupt(); //Attach the RTC alarm interrupt
   void detachInterrupt(); //Detach the RTC alarm interrupt
+  void clearInterrupt(); //Clear RTC alarm interrupt
 
   uint32_t weekday; //0 to 6 representing the day of the week
   uint32_t century;

--- a/libraries/WDT/examples/Example3_WDT_LowPower/Example3_WDT_LowPower.ino
+++ b/libraries/WDT/examples/Example3_WDT_LowPower/Example3_WDT_LowPower.ino
@@ -1,6 +1,6 @@
 /*
   Author: Adam Garbo
-  Created: August 1st, 2020
+  Created: March 27th, 2021
   License: MIT. See SparkFun Arduino Apollo3 Project for more information
 
   This example demonstrates the combined use of the Artemis Watchdog Timer (WDT)
@@ -106,12 +106,10 @@ void goToSleep()
   for (int x = 0 ; x < 50 ; x++)
     am_hal_gpio_pinconfig(x, g_AM_HAL_GPIO_DISABLE);
 
-  //Power down Flash, SRAM, cache
-  am_hal_pwrctrl_memory_deepsleep_powerdown(AM_HAL_PWRCTRL_MEM_CACHE); // Turn off CACHE
-  am_hal_pwrctrl_memory_deepsleep_powerdown(AM_HAL_PWRCTRL_MEM_FLASH_512K); // Turn off everything but lower 512k
-  am_hal_pwrctrl_memory_deepsleep_powerdown(AM_HAL_PWRCTRL_MEM_SRAM_64K_DTCM); // Turn off everything but lower 64k
-  //am_hal_pwrctrl_memory_deepsleep_powerdown(AM_HAL_PWRCTRL_MEM_ALL); //Turn off all memory (doesn't recover)
-
+  //Power down flash, SRAM, cache
+  am_hal_pwrctrl_memory_deepsleep_powerdown(AM_HAL_PWRCTRL_MEM_ALL); // Power down all cache and flash (~110 uA)
+  am_hal_pwrctrl_memory_deepsleep_retain(AM_HAL_PWRCTRL_MEM_SRAM_384K); // Retain all SRAM (~0.6 uA)
+  
   // Keep the 32kHz clock running for RTC
   am_hal_stimer_config(AM_HAL_STIMER_CFG_CLEAR | AM_HAL_STIMER_CFG_FREEZE);
   am_hal_stimer_config(AM_HAL_STIMER_XTAL_32KHZ);
@@ -125,9 +123,6 @@ void goToSleep()
 // Power up gracefully
 void wakeUp()
 {
-  // Power up SRAM, turn on entire Flash
-  am_hal_pwrctrl_memory_deepsleep_powerdown(AM_HAL_PWRCTRL_MEM_MAX);
-
   // Go back to using the main clock
   am_hal_stimer_config(AM_HAL_STIMER_CFG_CLEAR | AM_HAL_STIMER_CFG_FREEZE);
   am_hal_stimer_config(AM_HAL_STIMER_HFRC_3MHZ);


### PR DESCRIPTION
Hi @Wenn0101,

A very minor PR to correct the low-power code included in the RTC/WDT examples and add a clear interrupt function to the RTC library that I missed a long time ago.

My hope is that these changes can be included with a new artemis_svl file to make v1.2.1 compatible with macOS Big Sur.

Cheers,
Adam