### PR TITLE
Added missing SPI_HAS_TRANSACTION define, so libraries can tell that …

### DIFF
--- a/libraries/SPI/src/SPI.h
+++ b/libraries/SPI/src/SPI.h
@@ -10,6 +10,10 @@
 
 #include "drivers/SPI.h"
 
+// SPI_HAS_TRANSACTION means SPI has beginTransaction(), endTransaction(),
+// usingInterrupt(), and SPISetting(clock, bitOrder, dataMode)
+#define SPI_HAS_TRANSACTION 1
+
 namespace arduino {
 
 class MbedSPI : public SPIClass


### PR DESCRIPTION
…the API is available

See: https://github.com/arduino/ArduinoCore-avr/blob/24e6edd475c287cdafee0a4db2eb98927ce3cf58/libraries/SPI/src/SPI.h#L19-L21

Fx this is used by the USB Host Shield 2.0 library: https://github.com/felis/USB_Host_Shield_2.0/pull/654

Note that I did not add the SPI_HAS_NOTUSINGINTERRUPT define, as "usingInterrupt" and "notUsingInterrupt" are empty and should really be removed or implemented