### PR TITLE
added end method to PDM to facilitate stopping PDM

### DIFF
--- a/libraries/PDM/src/PDM.cpp
+++ b/libraries/PDM/src/PDM.cpp
@@ -37,6 +37,26 @@ bool AP3_PDM::begin(pin_size_t pinPDMData, pin_size_t pinPDMClock)
     return (true);
 }
 
+bool AP3_PDM::end()
+{
+    uint32_t retval = am_hal_pdm_disable(_PDMhandle);
+    if (retval != AP3_OK)
+    {
+        return false;
+    }
+    retval = (uint32_t)am_hal_pdm_power_control(_PDMhandle, AM_HAL_PDM_POWER_OFF, false);
+    if (retval != AP3_OK)
+    {
+        return retval;
+    }
+    retval = am_hal_pdm_deinitialize(_PDMhandle);
+    if (retval != AP3_OK)
+    {
+        return false;
+    }
+    return true;
+}
+
 bool AP3_PDM::available(void)
 {
     if (buff1New || buff2New)

--- a/libraries/PDM/src/PDM.h
+++ b/libraries/PDM/src/PDM.h
@@ -96,6 +96,7 @@ public:
     //AP3_PDM(uint16_t *userBuffer, uint32_t bufferSize);
 
     bool begin(pin_size_t pinPDMData = MIC_DATA, pin_size_t pinPDMClock = MIC_CLOCK);
+    bool end();
     bool available(void); //Goes true if circular buffer is not empty
     bool isOverrun(void); //Goes true if head crosses tail
 


### PR DESCRIPTION
Stopping PDM functionality may be useful to others.  In order to properly put apollo3 to sleep it is necessary to stop and re-initialize the PDM system.